### PR TITLE
Feature: Slack 웹훅 관련 기능 및 에러 핸들러 구현

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,11 +55,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-#      - name: publish unit test results
-#        uses: EnricoMi/publish-unit-test-result-action@v2
-#        if: always()
-#        with:
-#          files: ./cakk-api/build/test-results/**/*.xml
+      - name: publish unit test results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()
+        with:
+          files: ./cakk-api/build/test-results/**/*.xml
 
 #      - name: Upload test coverage
 #        id: jacoco

--- a/cakk-api/src/main/java/com/cakk/api/config/GoogleConfig.java
+++ b/cakk-api/src/main/java/com/cakk/api/config/GoogleConfig.java
@@ -13,8 +13,11 @@ import com.google.api.client.json.gson.GsonFactory;
 @Configuration
 public class GoogleConfig {
 
-	@Value("${oauth.google.client-id}")
-	private String googleClientId;
+	private final String googleClientId;
+
+	public GoogleConfig(@Value("${oauth.google.client-id}") String googleClientId) {
+		this.googleClientId = googleClientId;
+	}
 
 	@Bean
 	public GoogleIdTokenVerifier googleIdTokenVerifier() {

--- a/cakk-api/src/main/java/com/cakk/api/config/JwtConfig.java
+++ b/cakk-api/src/main/java/com/cakk/api/config/JwtConfig.java
@@ -12,8 +12,11 @@ import io.jsonwebtoken.security.Keys;
 @Configuration
 public class JwtConfig {
 
-	@Value("${jwt.secret}")
-	private String secretKey;
+	private final String secretKey;
+
+	public JwtConfig(@Value("${jwt.secret}") String secretKey) {
+		this.secretKey = secretKey;
+	}
 
 	@Bean
 	public Key key() {

--- a/cakk-api/src/main/java/com/cakk/api/config/SlackWebhookConfig.java
+++ b/cakk-api/src/main/java/com/cakk/api/config/SlackWebhookConfig.java
@@ -1,0 +1,19 @@
+package com.cakk.api.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import net.gpedro.integrations.slack.SlackApi;
+
+@Configuration
+public class SlackWebhookConfig {
+
+	@Value("${slack.webhook.url}")
+	private String slackWebhookUrl;
+
+	@Bean
+	public SlackApi slackApi() {
+		return new SlackApi(slackWebhookUrl);
+	}
+}

--- a/cakk-api/src/main/java/com/cakk/api/config/SlackWebhookConfig.java
+++ b/cakk-api/src/main/java/com/cakk/api/config/SlackWebhookConfig.java
@@ -9,8 +9,11 @@ import net.gpedro.integrations.slack.SlackApi;
 @Configuration
 public class SlackWebhookConfig {
 
-	@Value("${slack.webhook.url}")
-	private String slackWebhookUrl;
+	private final String slackWebhookUrl;
+
+	public SlackWebhookConfig(@Value("${slack.webhook.url}") String slackWebhookUrl) {
+		this.slackWebhookUrl = slackWebhookUrl;
+	}
 
 	@Bean
 	public SlackApi slackApi() {

--- a/cakk-api/src/main/java/com/cakk/api/controller/advice/GlobalControllerAdvice.java
+++ b/cakk-api/src/main/java/com/cakk/api/controller/advice/GlobalControllerAdvice.java
@@ -1,0 +1,76 @@
+package com.cakk.api.controller.advice;
+
+import static org.springframework.http.HttpStatus.*;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+
+import java.sql.SQLException;
+import java.util.List;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+import lombok.RequiredArgsConstructor;
+
+import com.cakk.api.service.slack.SlackService;
+import com.cakk.common.enums.ReturnCode;
+import com.cakk.common.exception.CakkException;
+import com.cakk.common.response.ApiResponse;
+
+@RestControllerAdvice
+@RequiredArgsConstructor
+public class GlobalControllerAdvice {
+
+	private final SlackService slackService;
+
+	@ExceptionHandler(CakkException.class)
+	public ResponseEntity<ApiResponse<Void>> handleCakkException(CakkException exception, HttpServletRequest request) {
+		if (exception.getReturnCode().equals(ReturnCode.EXTERNAL_SERVER_ERROR)) {
+			slackService.sendSlackForError(exception, request);
+		}
+
+		return getResponseEntity(BAD_REQUEST, ApiResponse.fail(exception.getReturnCode()));
+	}
+
+	@ExceptionHandler(value = {
+		HttpMessageNotReadableException.class,
+		MissingServletRequestParameterException.class,
+		MethodArgumentTypeMismatchException.class
+	})
+	public ResponseEntity<ApiResponse<Void>> handleRequestException(Exception exception) {
+		return getResponseEntity(BAD_REQUEST, ApiResponse.fail(ReturnCode.WRONG_PARAMETER));
+	}
+
+	@ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+	public ResponseEntity<ApiResponse<Void>> handleMethodNotSupportedException(HttpRequestMethodNotSupportedException exception) {
+		return getResponseEntity(BAD_REQUEST, ApiResponse.fail(ReturnCode.METHOD_NOT_ALLOWED));
+	}
+
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	public ResponseEntity<ApiResponse<List<FieldError>>> badRequestExHandler(BindingResult bindingResult) {
+		return getResponseEntity(BAD_REQUEST, ApiResponse.fail(ReturnCode.WRONG_PARAMETER, bindingResult.getFieldErrors()));
+	}
+
+	@ExceptionHandler(value = {
+		SQLException.class,
+		RuntimeException.class
+	})
+	public ResponseEntity<ApiResponse<String>> handleServerException(SQLException exception, HttpServletRequest request) {
+		slackService.sendSlackForError(exception, request);
+		return getResponseEntity(INTERNAL_SERVER_ERROR, ApiResponse.error(ReturnCode.INTERNAL_SERVER_ERROR, exception.getMessage()));
+	}
+
+	private <T> ResponseEntity<ApiResponse<T>> getResponseEntity(HttpStatus status, ApiResponse<T> response) {
+		return ResponseEntity.status(status).body(response);
+	}
+}

--- a/cakk-api/src/main/java/com/cakk/api/provider/jwt/JwtProvider.java
+++ b/cakk-api/src/main/java/com/cakk/api/provider/jwt/JwtProvider.java
@@ -19,27 +19,38 @@ import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 
-import lombok.RequiredArgsConstructor;
-
 import com.cakk.api.vo.JsonWebToken;
 import com.cakk.api.vo.OAuthUserDetails;
 import com.cakk.common.exception.CakkException;
 import com.cakk.domain.entity.user.User;
 
 @Component
-@RequiredArgsConstructor
 public class JwtProvider {
 
 	private final Key key;
 
-	@Value("${jwt.expiration.access-token}")
-	private Long accessTokenExpiredSecond;
-	@Value("${jwt.expiration.refresh-token}")
-	private Long refreshTokenExpiredSecond;
-	@Value("${jwt.grant-type}")
-	private String grantType;
-	@Value("${jwt.user-key}")
-	private String userKey;
+	private final Long accessTokenExpiredSecond;
+	private final Long refreshTokenExpiredSecond;
+	private final String grantType;
+	private final String userKey;
+
+	public JwtProvider(
+		Key key,
+		@Value("${jwt.expiration.access-token}")
+		Long accessTokenExpiredSecond,
+		@Value("${jwt.expiration.refresh-token}")
+		Long refreshTokenExpiredSecond,
+		@Value("${jwt.grant-type}")
+		String grantType,
+		@Value("${jwt.user-key}")
+		String userKey
+	) {
+		this.key = key;
+		this.accessTokenExpiredSecond = accessTokenExpiredSecond;
+		this.refreshTokenExpiredSecond = refreshTokenExpiredSecond;
+		this.grantType = grantType;
+		this.userKey = userKey;
+	}
 
 	public JsonWebToken generateToken(final User user) {
 		if (isNull(user)) {

--- a/cakk-api/src/main/java/com/cakk/api/service/slack/SlackService.java
+++ b/cakk-api/src/main/java/com/cakk/api/service/slack/SlackService.java
@@ -1,0 +1,82 @@
+package com.cakk.api.service.slack;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Service;
+
+import net.gpedro.integrations.slack.SlackApi;
+import net.gpedro.integrations.slack.SlackAttachment;
+import net.gpedro.integrations.slack.SlackField;
+import net.gpedro.integrations.slack.SlackMessage;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class SlackService {
+
+	private final SlackApi slackApi;
+	private final Environment environment;
+
+	@Value("${slack.webhook.is-enable}")
+	private boolean isEnable;
+
+	public void sendSlackForError(Exception exception, HttpServletRequest request) {
+		if (!isEnable) {
+			return;
+		}
+
+		SlackAttachment slackAttachment = new SlackAttachment();
+		slackAttachment.setFallback("Error");
+		slackAttachment.setColor("danger");
+		slackAttachment.setTitle("Error Detect");
+		slackAttachment.setTitleLink(request.getContextPath());
+		slackAttachment.setText(Arrays.toString(exception.getStackTrace()));
+		slackAttachment.setFields(
+			List.of(
+				new SlackField().setTitle("Request URL").setValue(request.getRequestURL().toString()),
+				new SlackField().setTitle("Request Method").setValue(request.getMethod()),
+				new SlackField().setTitle("Request Parameter").setValue(getRequestParameters(request)),
+				new SlackField().setTitle("Request Time").setValue(LocalDateTime.now().toString()),
+				new SlackField().setTitle("Request IP").setValue(request.getRemoteAddr()),
+				new SlackField().setTitle("Request User-Agent").setValue(request.getHeader("User-Agent"))
+			)
+		);
+
+		String profile = environment.getProperty("spring.profiles.default");
+		SlackMessage slackMessage = new SlackMessage();
+
+		slackMessage.setAttachments(List.of(slackAttachment));
+		slackMessage.setChannel("#error-log");
+		slackMessage.setUsername("%s API Error".formatted(profile));
+		slackMessage.setIcon(":alert:");
+		slackMessage.setText("%s api 에러 발생".formatted(profile));
+
+		slackApi.call(slackMessage);
+	}
+
+	private String getRequestParameters(HttpServletRequest request) {
+		Map<String, String[]> parameterMap = request.getParameterMap();
+
+		StringBuilder sb = new StringBuilder();
+		for (Map.Entry<String, String[]> entry : parameterMap.entrySet()) {
+			String key = entry.getKey();
+			String[] values = entry.getValue();
+
+			sb.append("Parameter Name: ").append(key);
+
+			for (String value : values) {
+				sb.append("Parameter Value: ").append(value);
+			}
+		}
+
+		return sb.toString();
+	}
+}

--- a/cakk-api/src/main/java/com/cakk/api/service/slack/SlackService.java
+++ b/cakk-api/src/main/java/com/cakk/api/service/slack/SlackService.java
@@ -8,7 +8,6 @@ import java.util.Map;
 import jakarta.servlet.http.HttpServletRequest;
 
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Service;
 
 import net.gpedro.integrations.slack.SlackApi;
@@ -16,17 +15,25 @@ import net.gpedro.integrations.slack.SlackAttachment;
 import net.gpedro.integrations.slack.SlackField;
 import net.gpedro.integrations.slack.SlackMessage;
 
-import lombok.RequiredArgsConstructor;
-
 @Service
-@RequiredArgsConstructor
 public class SlackService {
 
 	private final SlackApi slackApi;
-	private final Environment environment;
 
-	@Value("${slack.webhook.is-enable}")
-	private boolean isEnable;
+	private final String profile;
+	private final boolean isEnable;
+
+	public SlackService(
+		SlackApi slackApi,
+		@Value("${spring.profiles.default}")
+		String profile,
+		@Value("${slack.webhook.is-enable}")
+		boolean isEnable
+	) {
+		this.slackApi = slackApi;
+		this.profile = profile;
+		this.isEnable = isEnable;
+	}
 
 	public void sendSlackForError(Exception exception, HttpServletRequest request) {
 		if (!isEnable) {
@@ -50,7 +57,6 @@ public class SlackService {
 			)
 		);
 
-		String profile = environment.getProperty("spring.profiles.default");
 		SlackMessage slackMessage = new SlackMessage();
 
 		slackMessage.setAttachments(List.of(slackAttachment));

--- a/cakk-api/src/main/java/com/cakk/api/service/slack/SlackService.java
+++ b/cakk-api/src/main/java/com/cakk/api/service/slack/SlackService.java
@@ -25,7 +25,7 @@ public class SlackService {
 
 	public SlackService(
 		SlackApi slackApi,
-		@Value("${spring.profiles.default}")
+		@Value("${spring.profiles.active}")
 		String profile,
 		@Value("${slack.webhook.is-enable}")
 		boolean isEnable

--- a/cakk-api/src/test/java/com/cakk/api/common/base/ProviderTest.java
+++ b/cakk-api/src/test/java/com/cakk/api/common/base/ProviderTest.java
@@ -3,11 +3,14 @@ package com.cakk.api.common.base;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
 import com.cakk.domain.config.JpaConfig;
 import com.navercorp.fixturemonkey.FixtureMonkey;
 import com.navercorp.fixturemonkey.api.introspector.ConstructorPropertiesArbitraryIntrospector;
 
 @Import(JpaConfig.class)
+@ActiveProfiles("test")
 @ExtendWith(MockitoExtension.class)
 public abstract class ProviderTest {
 

--- a/cakk-client/src/main/java/com/cakk/client/web/AppleAuthClient.java
+++ b/cakk-client/src/main/java/com/cakk/client/web/AppleAuthClient.java
@@ -4,18 +4,22 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
-import lombok.RequiredArgsConstructor;
-
 import com.cakk.client.vo.OidcPublicKeyList;
 
 @Component
-@RequiredArgsConstructor
 public class AppleAuthClient {
 
 	private final RestClient restClient;
 
-	@Value("${oauth.apple.public-key-url}")
 	private final String publicKeyUrl;
+
+	public AppleAuthClient(
+		RestClient restClient,
+		@Value("${oauth.apple.public-key-url}") String publicKeyUrl
+	) {
+		this.restClient = restClient;
+		this.publicKeyUrl = publicKeyUrl;
+	}
 
 	public OidcPublicKeyList getPublicKeys() {
 		return restClient.get()

--- a/cakk-client/src/main/java/com/cakk/client/web/KakaoAuthClient.java
+++ b/cakk-client/src/main/java/com/cakk/client/web/KakaoAuthClient.java
@@ -4,18 +4,22 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
-import lombok.RequiredArgsConstructor;
-
 import com.cakk.client.vo.OidcPublicKeyList;
 
 @Component
-@RequiredArgsConstructor
 public class KakaoAuthClient {
 
 	private final RestClient restClient;
 
-	@Value("${oauth.kakao.public-key-url}")
 	private final String publicKeyUrl;
+
+	public KakaoAuthClient(
+		RestClient restClient,
+		@Value("${oauth.kakao.public-key-info}") String publicKeyUrl
+	) {
+		this.restClient = restClient;
+		this.publicKeyUrl = publicKeyUrl;
+	}
 
 	public OidcPublicKeyList getPublicKeys() {
 		return restClient.get()

--- a/cakk-client/src/main/resources/client-local.yml
+++ b/cakk-client/src/main/resources/client-local.yml
@@ -1,7 +1,0 @@
-oauth:
-  kakao:
-    public-key-info: https://kauth.kakao.com/.well-known/jwks.json
-  apple:
-    public-key-url: https://appleid.apple.com/auth/keys
-  google:
-      client-id: ${GOOGLE_CLIENT_ID}

--- a/cakk-common/src/main/java/com/cakk/common/enums/ReturnCode.java
+++ b/cakk-common/src/main/java/com/cakk/common/enums/ReturnCode.java
@@ -16,6 +16,10 @@ public enum ReturnCode {
 	EMPTY_AUTH_JWT("1103", "인증 정보가 비어있는 jwt 토큰입니다."),
 	EMPTY_USER("1104", "비어있는 유저 정보로 jwt 토큰을 생성할 수 없습니다."),
 
+	// 클라이언트 에러
+	WRONG_PARAMETER("9000", "잘못된 파라미터 입니다."),
+	METHOD_NOT_ALLOWED("9001", "허용되지 않은 메소드 입니다."),
+
 	// 서버 에러 (9998, 9999)
 	INTERNAL_SERVER_ERROR("9998", "내부 서버 에러 입니다."),
 	EXTERNAL_SERVER_ERROR("9999", "외부 서버 에러 입니다.");

--- a/cakk-common/src/main/java/com/cakk/common/exception/CakkException.java
+++ b/cakk-common/src/main/java/com/cakk/common/exception/CakkException.java
@@ -7,10 +7,12 @@ import com.cakk.common.enums.ReturnCode;
 @Getter
 public class CakkException extends RuntimeException {
 
+	private final ReturnCode returnCode;
 	private final String code;
 	private final String message;
 
 	public CakkException(ReturnCode returnCode) {
+		this.returnCode = returnCode;
 		this.code = returnCode.getCode();
 		this.message = returnCode.getMessage();
 	}

--- a/cakk-common/src/main/java/com/cakk/common/response/ApiResponse.java
+++ b/cakk-common/src/main/java/com/cakk/common/response/ApiResponse.java
@@ -21,6 +21,16 @@ public class ApiResponse<T> {
 		return response;
 	}
 
+	public static <T> ApiResponse<T> fail(ReturnCode returnCode) {
+		ApiResponse<T> response = new ApiResponse<>();
+
+		response.returnCode = returnCode.getCode();
+		response.returnMessage = returnCode.getMessage();
+		response.data = null;
+
+		return response;
+	}
+
 	public static <T> ApiResponse<T> fail(ReturnCode returnCode, T data) {
 		ApiResponse<T> response = new ApiResponse<>();
 


### PR DESCRIPTION
> ### Issue Number

#4

> ### Description

- Slack Webhook을 설정하고 관련 기능을 구현했습니다.
- ControllerAdvice를 활용하여 에러 핸들러를 구현했습니다.

> ### Core Code

```java
. . . 
        @ExceptionHandler(CakkException.class)
	public ResponseEntity<ApiResponse<Void>> handleCakkException(CakkException exception, HttpServletRequest request) {
		if (exception.getReturnCode().equals(ReturnCode.EXTERNAL_SERVER_ERROR)) {
			slackService.sendSlackForError(exception, request);
		}

		return getResponseEntity(BAD_REQUEST, ApiResponse.fail(exception.getReturnCode()));
	}
. . .
```

모든 실패 응답은 400, 서버 에러는 500을 던졌습니다. Slack 관련 기능은 사업자 인증 관련해서 확장하여 사용해도 될거 같습니다.

> ### etc
