### PR TITLE
Feature: 사장 인증 외부 서비스 연동 및 비즈니스 로직 변경

### DIFF
--- a/cakk-api/src/main/java/com/cakk/api/config/AsyncConfig.java
+++ b/cakk-api/src/main/java/com/cakk/api/config/AsyncConfig.java
@@ -1,0 +1,9 @@
+package com.cakk.api.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+}

--- a/cakk-api/src/main/java/com/cakk/api/controller/shop/ShopController.java
+++ b/cakk-api/src/main/java/com/cakk/api/controller/shop/ShopController.java
@@ -2,6 +2,7 @@ package com.cakk.api.controller.shop;
 
 import jakarta.validation.Valid;
 
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -9,6 +10,9 @@ import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
 
+import com.cakk.api.annotation.SignInUser;
+import com.cakk.api.dto.request.shop.CreateShopRequest;
+import com.cakk.api.dto.request.shop.PromotionRequest;
 import com.cakk.api.dto.request.user.CertificationRequest;
 import com.cakk.api.service.shop.ShopService;
 import com.cakk.common.response.ApiResponse;
@@ -23,9 +27,25 @@ public class ShopController {
 
 	@PostMapping("/certification")
 	public ApiResponse<Void> requestCertification(
-		User user,
+		@SignInUser User user,
 		@Valid @RequestBody CertificationRequest certificationRequest) {
 		shopService.requestCertificationBusinessOwner(certificationRequest.from(user));
+		return ApiResponse.success(null);
+	}
+
+	@PostMapping("/admin/create")
+	public ApiResponse<Void> createCakeShopByAdmin(
+		@Valid @RequestBody CreateShopRequest createShopRequest
+	) {
+		shopService.createCakeShopByCertification(createShopRequest);
+		return ApiResponse.success(null);
+	}
+
+	@PatchMapping("/admin/promote")
+	public ApiResponse<Void> promoteUser(
+		@Valid @RequestBody PromotionRequest promotionRequest
+	) {
+		shopService.promoteUserToBusinessOwner(promotionRequest);
 		return ApiResponse.success(null);
 	}
 

--- a/cakk-api/src/main/java/com/cakk/api/controller/shop/ShopController.java
+++ b/cakk-api/src/main/java/com/cakk/api/controller/shop/ShopController.java
@@ -30,7 +30,7 @@ public class ShopController {
 		@SignInUser User user,
 		@Valid @RequestBody CertificationRequest certificationRequest) {
 		shopService.requestCertificationBusinessOwner(certificationRequest.from(user));
-		return ApiResponse.success(null);
+		return ApiResponse.success();
 	}
 
 	@PostMapping("/admin/create")
@@ -38,7 +38,7 @@ public class ShopController {
 		@Valid @RequestBody CreateShopRequest createShopRequest
 	) {
 		shopService.createCakeShopByCertification(createShopRequest);
-		return ApiResponse.success(null);
+		return ApiResponse.success();
 	}
 
 	@PatchMapping("/admin/promote")
@@ -46,7 +46,7 @@ public class ShopController {
 		@Valid @RequestBody PromotionRequest promotionRequest
 	) {
 		shopService.promoteUserToBusinessOwner(promotionRequest);
-		return ApiResponse.success(null);
+		return ApiResponse.success();
 	}
 
 }

--- a/cakk-api/src/main/java/com/cakk/api/event/shop/listener/CertificationEventListener.java
+++ b/cakk-api/src/main/java/com/cakk/api/event/shop/listener/CertificationEventListener.java
@@ -1,5 +1,6 @@
 package com.cakk.api.event.shop.listener;
 
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -14,6 +15,7 @@ import com.cakk.domain.event.shop.CertificationEvent;
 public class CertificationEventListener {
 	private final SlackService slackService;
 
+	@Async
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
 	public void sendMessageToSlack(CertificationEvent certificationEvent) {
 	}

--- a/cakk-api/src/main/java/com/cakk/api/event/shop/listener/CertificationEventListener.java
+++ b/cakk-api/src/main/java/com/cakk/api/event/shop/listener/CertificationEventListener.java
@@ -18,5 +18,6 @@ public class CertificationEventListener {
 	@Async
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
 	public void sendMessageToSlack(CertificationEvent certificationEvent) {
+		slackService.sendSlackForCertification(certificationEvent);
 	}
 }

--- a/cakk-api/src/main/java/com/cakk/api/event/shop/listener/CertificationEventListener.java
+++ b/cakk-api/src/main/java/com/cakk/api/event/shop/listener/CertificationEventListener.java
@@ -13,6 +13,7 @@ import com.cakk.domain.event.shop.CertificationEvent;
 @RequiredArgsConstructor
 @Component
 public class CertificationEventListener {
+
 	private final SlackService slackService;
 
 	@Async

--- a/cakk-api/src/main/java/com/cakk/api/service/shop/ShopService.java
+++ b/cakk-api/src/main/java/com/cakk/api/service/shop/ShopService.java
@@ -13,6 +13,7 @@ import com.cakk.domain.dto.param.user.CertificationParam;
 import com.cakk.domain.entity.shop.CakeShop;
 import com.cakk.domain.entity.user.BusinessInformation;
 import com.cakk.domain.entity.user.User;
+import com.cakk.domain.event.shop.CertificationEvent;
 import com.cakk.domain.repository.reader.CakeShopReader;
 import com.cakk.domain.repository.reader.UserReader;
 import com.cakk.domain.repository.writer.CakeShopWriter;
@@ -52,7 +53,8 @@ public class ShopService {
 			businessInformation = ShopMapper.supplyBusinessInformationBy();
 		}
 
-		businessInformation.requestCertificationToApp(param, publisher);
+		CertificationEvent certificationEvent = businessInformation.getRequestCertificationMessage(param);
+		publisher.publishEvent(certificationEvent);
 	}
 
 }

--- a/cakk-api/src/main/java/com/cakk/api/service/slack/SlackService.java
+++ b/cakk-api/src/main/java/com/cakk/api/service/slack/SlackService.java
@@ -15,6 +15,8 @@ import net.gpedro.integrations.slack.SlackAttachment;
 import net.gpedro.integrations.slack.SlackField;
 import net.gpedro.integrations.slack.SlackMessage;
 
+import com.cakk.domain.event.shop.CertificationEvent;
+
 @Service
 public class SlackService {
 
@@ -64,6 +66,36 @@ public class SlackService {
 		slackMessage.setUsername("%s API Error".formatted(profile));
 		slackMessage.setIcon(":alert:");
 		slackMessage.setText("%s api 에러 발생".formatted(profile));
+
+		slackApi.call(slackMessage);
+	}
+
+	public void sendSlackForCertification(CertificationEvent certificationEvent) {
+		if (!isEnable) {
+			return;
+		}
+
+		SlackAttachment slackAttachment = new SlackAttachment();
+		slackAttachment.setColor("good");
+		slackAttachment.setFallback("OK");
+		slackAttachment.setTitle("Request Certification");
+		slackAttachment.setFields(List.of(
+			new SlackField().setTitle("요청자 PK").setValue(String.valueOf(certificationEvent.userId())),
+			new SlackField().setTitle("요청자 이메일").setValue(certificationEvent.userEmail()),
+			new SlackField().setTitle("요청자 비상연락망").setValue(certificationEvent.emergencyContact()),
+			new SlackField().setTitle("요청자 신분증 이미지").setValue(certificationEvent.idCardImageUrl()),
+			new SlackField().setTitle("요청자 사업자등록증 이미지").setValue(certificationEvent.businessRegistrationImageUrl()),
+			new SlackField().setTitle("요청 사항").setValue(certificationEvent.message()),
+			new SlackField().setTitle("가게 이름").setValue(certificationEvent.shopName()),
+			new SlackField().setTitle("가게 위치 위도").setValue(String.valueOf(certificationEvent.shopLatitude())),
+			new SlackField().setTitle("가게 위치 경도").setValue(String.valueOf(certificationEvent.shopLongitude()))
+		));
+
+		SlackMessage slackMessage = new SlackMessage();
+
+		slackMessage.setAttachments(List.of(slackAttachment));
+		slackMessage.setChannel("#cs_사장님인증");
+		slackMessage.setText("%s 사장님 인증 요청".formatted(profile));
 
 		slackApi.call(slackMessage);
 	}

--- a/cakk-common/src/main/java/com/cakk/common/response/ApiResponse.java
+++ b/cakk-common/src/main/java/com/cakk/common/response/ApiResponse.java
@@ -11,6 +11,16 @@ public class ApiResponse<T> {
 	private String returnMessage;
 	private T data;
 
+	public static <T> ApiResponse<T> success() {
+		ApiResponse<T> response = new ApiResponse<>();
+
+		response.returnCode = ReturnCode.SUCCESS.getCode();
+		response.returnMessage = ReturnCode.SUCCESS.getMessage();
+		response.data = null;
+
+		return response;
+	}
+
 	public static <T> ApiResponse<T> success(T data) {
 		ApiResponse<T> response = new ApiResponse<>();
 

--- a/cakk-domain/build.gradle
+++ b/cakk-domain/build.gradle
@@ -7,6 +7,12 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'io.hypersistence:hypersistence-utils-hibernate-63:3.7.4'
 
+	// test
+	testImplementation("com.navercorp.fixturemonkey:fixture-monkey-starter:1.0.16")
+	testImplementation('org.assertj:assertj-core')
+	testImplementation('org.junit.jupiter:junit-jupiter')
+	testRuntimeOnly('org.junit.platform:junit-platform-launcher')
+
     // querydsl
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
     annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'

--- a/cakk-domain/src/main/java/com/cakk/domain/entity/user/BusinessInformation.java
+++ b/cakk-domain/src/main/java/com/cakk/domain/entity/user/BusinessInformation.java
@@ -12,8 +12,6 @@ import jakarta.persistence.MapsId;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 
-import org.springframework.context.ApplicationEventPublisher;
-
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -74,19 +72,16 @@ public class BusinessInformation extends AuditEntity {
 		this.user = user;
 	}
 
-	public void requestCertificationToApp(CertificationParam param, ApplicationEventPublisher publisher) {
-		CertificationEvent certificationEvent;
-
+	public CertificationEvent getRequestCertificationMessage(CertificationParam param) {
 		if (isExistMyCakeShop()) {
-			certificationEvent = EventMapper.supplyCertificationInfoWithCakeShopInfo(param, cakeShop);
-		} else {
-			certificationEvent = EventMapper.supplyCertificationInfo(param);
+			return EventMapper.supplyCertificationInfoWithCakeShopInfo(param, cakeShop);
 		}
-		publisher.publishEvent(certificationEvent);
+		return EventMapper.supplyCertificationInfo(param);
+
 	}
 
-	public void promotedByBusinessOwner(User shopKeeper) {
-		user = shopKeeper;
+	public void promotedByBusinessOwner(User businessOwner) {
+		user = businessOwner;
 		cakeShop.ownedByUser();
 	}
 

--- a/cakk-domain/src/test/java/com/cakk/domain/entity/user/BusinessInformationTest.java
+++ b/cakk-domain/src/test/java/com/cakk/domain/entity/user/BusinessInformationTest.java
@@ -1,0 +1,87 @@
+package com.cakk.domain.entity.user;
+
+import static org.assertj.core.api.Assertions.*;
+import org.junit.Test;
+
+import net.jqwik.api.Arbitraries;
+
+import com.cakk.domain.dto.param.user.CertificationParam;
+import com.cakk.domain.entity.shop.CakeShop;
+import com.cakk.domain.event.shop.CertificationEvent;
+
+import com.navercorp.fixturemonkey.FixtureMonkey;
+import com.navercorp.fixturemonkey.api.introspector.BuilderArbitraryIntrospector;
+import com.navercorp.fixturemonkey.api.introspector.FieldReflectionArbitraryIntrospector;
+
+public class BusinessInformationTest {
+
+	@Test
+	public void 케이크샵이_존재한다면_가게_정보와_함께_서비스에_인증요청을_한다() {
+		//given
+		CakeShop cakeShop = getReflectionMonkey().giveMeBuilder(CakeShop.class)
+			.set("shopName", Arbitraries.strings().withCharRange('a', 'z').ofMaxLength(30))
+			.sample();
+		BusinessInformation businessInformation = getReflectionMonkey().giveMeBuilder(BusinessInformation.class)
+			.set("cakeShop", cakeShop)
+			.setNull("user").sample();
+		User user = getReflectionMonkey().giveMeBuilder(User.class)
+			.set("id", Arbitraries.longs().greaterOrEqual(10))
+			.sample();
+		CertificationParam param = getBuilderMonkey().giveMeBuilder(CertificationParam.class)
+			.set("user", user)
+			.sample();
+
+		//when
+		CertificationEvent certificationEvent = businessInformation.getRequestCertificationMessage(param);
+
+		//then
+		assertThat(certificationEvent.shopName()).isNotNull();
+	}
+
+	@Test
+	public void 케이크샵이_존재하지_않는다면_가게_정보_없이_서비스에_인증요청을_한다() {
+		//given
+		BusinessInformation businessInformation = getReflectionMonkey().giveMeBuilder(BusinessInformation.class).sample();
+		User user = getReflectionMonkey().giveMeBuilder(User.class)
+			.set("id", Arbitraries.longs().greaterOrEqual(10))
+			.sample();
+		CertificationParam param = getBuilderMonkey().giveMeBuilder(CertificationParam.class)
+			.set("user", user)
+			.sample();
+
+		//when
+		CertificationEvent certificationEvent = businessInformation.getRequestCertificationMessage(param);
+
+		//then
+		assertThat(certificationEvent.shopName()).isNull();
+	}
+
+	@Test
+	public void 사용자는_케이크샵의_주인으로_승격된다() {
+		//given
+		CakeShop cakeShop = getReflectionMonkey().giveMeOne(CakeShop.class);
+		BusinessInformation businessInformation = getReflectionMonkey().giveMeBuilder(BusinessInformation.class)
+			.set("cakeShop", cakeShop)
+			.sample();
+		User user = getReflectionMonkey().giveMeOne(User.class);
+
+		//when
+		businessInformation.promotedByBusinessOwner(user);
+
+		//then
+		assertThat(businessInformation.getUser()).isNotNull();
+		assertThat(businessInformation.getCakeShop().getLinkedFlag()).isTrue();
+	}
+
+	public FixtureMonkey getReflectionMonkey() {
+		return FixtureMonkey.builder()
+			.objectIntrospector(FieldReflectionArbitraryIntrospector.INSTANCE)
+			.build();
+	}
+
+	public FixtureMonkey getBuilderMonkey() {
+		return FixtureMonkey.builder()
+			.objectIntrospector(BuilderArbitraryIntrospector.INSTANCE)
+			.build();
+	}
+}

--- a/cakk-domain/src/test/java/com/cakk/domain/entity/user/BusinessInformationTest.java
+++ b/cakk-domain/src/test/java/com/cakk/domain/entity/user/BusinessInformationTest.java
@@ -1,7 +1,8 @@
 package com.cakk.domain.entity.user;
 
 import static org.assertj.core.api.Assertions.*;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 
 import net.jqwik.api.Arbitraries;
 
@@ -13,10 +14,10 @@ import com.navercorp.fixturemonkey.FixtureMonkey;
 import com.navercorp.fixturemonkey.api.introspector.BuilderArbitraryIntrospector;
 import com.navercorp.fixturemonkey.api.introspector.FieldReflectionArbitraryIntrospector;
 
-public class BusinessInformationTest {
+class BusinessInformationTest {
 
 	@Test
-	public void 케이크샵이_존재한다면_가게_정보와_함께_서비스에_인증요청을_한다() {
+	void 케이크샵이_존재한다면_가게_정보와_함께_서비스에_인증요청을_한다() {
 		//given
 		CakeShop cakeShop = getReflectionMonkey().giveMeBuilder(CakeShop.class)
 			.set("shopName", Arbitraries.strings().withCharRange('a', 'z').ofMaxLength(30))
@@ -39,7 +40,7 @@ public class BusinessInformationTest {
 	}
 
 	@Test
-	public void 케이크샵이_존재하지_않는다면_가게_정보_없이_서비스에_인증요청을_한다() {
+	void 케이크샵이_존재하지_않는다면_가게_정보_없이_서비스에_인증요청을_한다() {
 		//given
 		BusinessInformation businessInformation = getReflectionMonkey().giveMeBuilder(BusinessInformation.class).sample();
 		User user = getReflectionMonkey().giveMeBuilder(User.class)
@@ -57,7 +58,7 @@ public class BusinessInformationTest {
 	}
 
 	@Test
-	public void 사용자는_케이크샵의_주인으로_승격된다() {
+	void 사용자는_케이크샵의_주인으로_승격된다() {
 		//given
 		CakeShop cakeShop = getReflectionMonkey().giveMeOne(CakeShop.class);
 		BusinessInformation businessInformation = getReflectionMonkey().giveMeBuilder(BusinessInformation.class)
@@ -73,13 +74,13 @@ public class BusinessInformationTest {
 		assertThat(businessInformation.getCakeShop().getLinkedFlag()).isTrue();
 	}
 
-	public FixtureMonkey getReflectionMonkey() {
+	private FixtureMonkey getReflectionMonkey() {
 		return FixtureMonkey.builder()
 			.objectIntrospector(FieldReflectionArbitraryIntrospector.INSTANCE)
 			.build();
 	}
 
-	public FixtureMonkey getBuilderMonkey() {
+	private FixtureMonkey getBuilderMonkey() {
 		return FixtureMonkey.builder()
 			.objectIntrospector(BuilderArbitraryIntrospector.INSTANCE)
 			.build();


### PR DESCRIPTION
> ### Issue Number

#14 

> ### Description

- FixtureMonkey를 활용한 비즈니스 로직 테스트 코드
- 테스트 코드를 작성하면서 Entity에서 EventPublisher를 계속 받아와서 이벤트를 publish까지 하는 로직은 클래스의 응집도가 떨어진다고 판단해서 로직을 변경했습니다. 따라서, 조건에 따라 EventMessage를 만들어주는 책임만을 부여했습니다
- 외부 서비스(슬랙에 메시지 전송)를 이용하는 것이 동기적으로 이루어진다면,  불필요한 병목현상이 발생하기 때문에 비동기 방식으로 변경했습니다

> ### Core Code
비즈니스 로직 코드 변경 
케이크 샵이 존재하면 케이크샵 정보와 함께 슬랙에 보낼 메시지를 Return 해주는 책임 / 없다면 유저 관련 정보만 Return 해주는 책임
```java
if (isExistMyCakeShop()) {
    return EventMapper.supplyCertificationInfoWithCakeShopInfo(param, cakeShop);
}
return EventMapper.supplyCertificationInfo(param);
```

> ### etc
