### PR TITLE
Feature: 카테고리별 케이크 사진 조회 비즈니스 구현

### DIFF
--- a/cakk-api/src/main/java/com/cakk/api/dto/request/cake/CakeSearchByCategoryRequest.java
+++ b/cakk-api/src/main/java/com/cakk/api/dto/request/cake/CakeSearchByCategoryRequest.java
@@ -3,7 +3,6 @@ package com.cakk.api.dto.request.cake;
 import com.cakk.common.enums.CakeDesignCategory;
 
 public record CakeSearchByCategoryRequest(
-
 	Long cakeId,
 	CakeDesignCategory category,
 	int pageSize

--- a/cakk-api/src/main/java/com/cakk/api/dto/request/cake/CakeSearchByCategoryRequest.java
+++ b/cakk-api/src/main/java/com/cakk/api/dto/request/cake/CakeSearchByCategoryRequest.java
@@ -1,0 +1,11 @@
+package com.cakk.api.dto.request.cake;
+
+import com.cakk.common.enums.CakeDesignCategory;
+
+public record CakeSearchByCategoryRequest(
+
+	Long cakeId,
+	CakeDesignCategory category,
+	int pageSize
+) {
+}

--- a/cakk-api/src/main/java/com/cakk/api/dto/response/cake/CakeImageListResponse.java
+++ b/cakk-api/src/main/java/com/cakk/api/dto/response/cake/CakeImageListResponse.java
@@ -1,0 +1,26 @@
+package com.cakk.api.dto.response.cake;
+
+import java.util.List;
+
+import lombok.Builder;
+
+import com.cakk.domain.dto.param.cake.CakeImageResponseParam;
+
+@Builder
+public record CakeImageListResponse(
+
+	List<CakeImageResponseParam> cakeImages,
+	Long lastCakeId,
+	int size
+) {
+
+	public static CakeImageListResponse from(List<CakeImageResponseParam> cakeImages) {
+		int size = cakeImages.size();
+
+		return CakeImageListResponse.builder()
+			.cakeImages(cakeImages)
+			.lastCakeId(cakeImages.isEmpty() ? null : cakeImages.get(size - 1).cakeId())
+			.size(cakeImages.size())
+			.build();
+	}
+}

--- a/cakk-api/src/main/java/com/cakk/api/service/cake/CakeService.java
+++ b/cakk-api/src/main/java/com/cakk/api/service/cake/CakeService.java
@@ -1,0 +1,20 @@
+package com.cakk.api.service.cake;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+import com.cakk.api.dto.request.cake.CakeSearchByCategoryRequest;
+import com.cakk.api.dto.response.cake.CakeImageListResponse;
+import com.cakk.domain.repository.reader.CakeReader;
+
+@Service
+@RequiredArgsConstructor
+public class CakeService {
+
+	private final CakeReader cakeReader;
+
+	public CakeImageListResponse findCakeImagesByCursorAndCategory(CakeSearchByCategoryRequest dto) {
+		return CakeImageListResponse.from(cakeReader.findCakeImagesByCursorAndCategory(dto.cakeId(), dto.category(), dto.pageSize()));
+	}
+}

--- a/cakk-api/src/test/java/com/cakk/api/service/cake/CakeServiceTest.java
+++ b/cakk-api/src/test/java/com/cakk/api/service/cake/CakeServiceTest.java
@@ -1,0 +1,65 @@
+package com.cakk.api.service.cake;
+
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import com.cakk.api.common.base.ServiceTest;
+import com.cakk.api.dto.request.cake.CakeSearchByCategoryRequest;
+import com.cakk.api.dto.response.cake.CakeImageListResponse;
+import com.cakk.common.enums.CakeDesignCategory;
+import com.cakk.domain.dto.param.cake.CakeImageResponseParam;
+import com.cakk.domain.repository.reader.CakeReader;
+
+@DisplayName("케이크 조회 관련 비즈니스 로직 테스트")
+class CakeServiceTest extends ServiceTest {
+
+	@InjectMocks
+	private CakeService cakeService;
+
+	@Mock
+	private CakeReader cakeReader;
+
+	@Test
+	void 카테고리에_해당하는_케이크_목록을_조회한다() {
+		// given
+		CakeSearchByCategoryRequest dto = new CakeSearchByCategoryRequest(null, CakeDesignCategory.FLOWER, 3);
+		List<CakeImageResponseParam> cakeImages = getConstructorMonkey().giveMe(CakeImageResponseParam.class, 3);
+
+		doReturn(cakeImages).when(cakeReader).findCakeImagesByCursorAndCategory(dto.cakeId(), dto.category(), dto.pageSize());
+
+		// when
+		CakeImageListResponse result = cakeService.findCakeImagesByCursorAndCategory(dto);
+
+		// then
+		Assertions.assertEquals(cakeImages.size(), result.cakeImages().size());
+		Assertions.assertNotNull(result.lastCakeId());
+
+		verify(cakeReader).findCakeImagesByCursorAndCategory(dto.cakeId(), dto.category(), dto.pageSize());
+	}
+
+	@Test
+	void 카테고리에_해당하는_케이크가_없을_시_빈_배열을_리턴한다() {
+		// given
+		CakeSearchByCategoryRequest dto = new CakeSearchByCategoryRequest(null, CakeDesignCategory.FLOWER, 3);
+		List<CakeImageResponseParam> cakeImages = getConstructorMonkey().giveMe(CakeImageResponseParam.class, 0);
+
+		doReturn(cakeImages).when(cakeReader).findCakeImagesByCursorAndCategory(dto.cakeId(), dto.category(), dto.pageSize());
+
+		// when
+		CakeImageListResponse result = cakeService.findCakeImagesByCursorAndCategory(dto);
+
+		// then
+		Assertions.assertEquals(cakeImages.size(), result.cakeImages().size());
+		Assertions.assertNull(result.lastCakeId());
+
+		verify(cakeReader).findCakeImagesByCursorAndCategory(dto.cakeId(), dto.category(), dto.pageSize());
+	}
+}

--- a/cakk-common/src/main/java/com/cakk/common/enums/CakeDesignCategory.java
+++ b/cakk-common/src/main/java/com/cakk/common/enums/CakeDesignCategory.java
@@ -2,5 +2,14 @@ package com.cakk.common.enums;
 
 public enum CakeDesignCategory {
 
-	FLOWER
+	THREE_DIMENSIONAL,
+	CHARACTER,
+	PHOTO,
+	LUNCHBOX,
+	FIGURE,
+	FLOWER,
+	LETTERING,
+	RICE_CAKE,
+	TIARA,
+	ETC
 }

--- a/cakk-domain/src/main/java/com/cakk/domain/dto/param/cake/CakeImageResponseParam.java
+++ b/cakk-domain/src/main/java/com/cakk/domain/dto/param/cake/CakeImageResponseParam.java
@@ -1,7 +1,6 @@
 package com.cakk.domain.dto.param.cake;
 
 public record CakeImageResponseParam(
-	
 	Long cakeShopId,
 	Long cakeId,
 	String cakeImageUrl

--- a/cakk-domain/src/main/java/com/cakk/domain/dto/param/cake/CakeImageResponseParam.java
+++ b/cakk-domain/src/main/java/com/cakk/domain/dto/param/cake/CakeImageResponseParam.java
@@ -1,0 +1,9 @@
+package com.cakk.domain.dto.param.cake;
+
+public record CakeImageResponseParam(
+	
+	Long cakeShopId,
+	Long cakeId,
+	String cakeImageUrl
+) {
+}

--- a/cakk-domain/src/main/java/com/cakk/domain/entity/shop/CakeShop.java
+++ b/cakk-domain/src/main/java/com/cakk/domain/entity/shop/CakeShop.java
@@ -29,6 +29,9 @@ public class CakeShop extends AuditEntity {
 	@Column(name = "shop_id", nullable = false)
 	private Long id;
 
+	@Column(name = "thumbnail_url", length = 200)
+	private String thumbnailUrl;
+
 	@Column(name = "shop_name", length = 30, nullable = false)
 	private String shopName;
 
@@ -57,8 +60,16 @@ public class CakeShop extends AuditEntity {
 	private LocalDateTime deletedAt;
 
 	@Builder
-	public CakeShop(String shopName, String shopBio, String shopDescription, Double latitude, Double longitude) {
+	public CakeShop(
+		String shopName,
+		String thumbnailUrl,
+		String shopBio,
+		String shopDescription,
+		Double latitude,
+		Double longitude
+	) {
 		this.shopName = shopName;
+		this.thumbnailUrl = thumbnailUrl;
 		this.shopBio = shopBio;
 		this.shopDescription = shopDescription;
 		this.latitude = latitude;

--- a/cakk-domain/src/main/java/com/cakk/domain/repository/query/CakeQueryRepository.java
+++ b/cakk-domain/src/main/java/com/cakk/domain/repository/query/CakeQueryRepository.java
@@ -1,0 +1,60 @@
+package com.cakk.domain.repository.query;
+
+import static com.cakk.domain.entity.cake.QCake.*;
+import static com.cakk.domain.entity.cake.QCakeCategory.*;
+import static com.cakk.domain.entity.shop.QCakeShop.*;
+import static java.util.Objects.*;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+import com.cakk.common.enums.CakeDesignCategory;
+import com.cakk.domain.dto.param.cake.CakeImageResponseParam;
+
+@RequiredArgsConstructor
+@Repository
+public class CakeQueryRepository {
+
+	private final JPAQueryFactory queryFactory;
+
+	public List<CakeImageResponseParam> findCakeImagesByCursorAndCategory(Long cakeId, CakeDesignCategory category, int pageSize) {
+		return queryFactory
+			.select(Projections.constructor(CakeImageResponseParam.class,
+				cakeShop.id,
+				cake.id,
+				cake.cakeImageUrl))
+			.from(cake)
+			.innerJoin(cake.cakeShop, cakeShop)
+			.innerJoin(cakeCategory.cake, cake)
+			.where(
+				ltCakeId(cakeId),
+				eqCategory(category))
+			.limit(pageSize)
+			.orderBy(cakeIdDesc())
+			.fetch();
+	}
+
+	private BooleanExpression ltCakeId(Long cakeId) {
+		if (isNull(cakeId)) {
+			return null;
+		}
+
+		return cake.id.lt(cakeId);
+	}
+
+	private BooleanExpression eqCategory(CakeDesignCategory category) {
+		return cakeCategory.cakeDesignCategory.eq(category);
+	}
+
+	private OrderSpecifier<Long> cakeIdDesc() {
+		return cake.id.desc();
+	}
+}

--- a/cakk-domain/src/main/java/com/cakk/domain/repository/reader/CakeReader.java
+++ b/cakk-domain/src/main/java/com/cakk/domain/repository/reader/CakeReader.java
@@ -1,0 +1,21 @@
+package com.cakk.domain.repository.reader;
+
+import java.util.List;
+
+import lombok.RequiredArgsConstructor;
+
+import com.cakk.common.enums.CakeDesignCategory;
+import com.cakk.domain.annotation.Reader;
+import com.cakk.domain.dto.param.cake.CakeImageResponseParam;
+import com.cakk.domain.repository.query.CakeQueryRepository;
+
+@Reader
+@RequiredArgsConstructor
+public class CakeReader {
+
+	private final CakeQueryRepository cakeQueryRepository;
+
+	public List<CakeImageResponseParam> findCakeImagesByCursorAndCategory(Long cakeId, CakeDesignCategory category, int pageSize) {
+		return cakeQueryRepository.findCakeImagesByCursorAndCategory(cakeId, category, pageSize);
+	}
+}

--- a/infra/nginx/Dockerfile
+++ b/infra/nginx/Dockerfile
@@ -1,0 +1,3 @@
+FROM nginx:1.19.6-alpine
+COPY ./config/nginx.conf /etc/nginx/conf.d/nginx.conf
+ENTRYPOINT ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
> ### Issue Number

#22

> ### Description

- 카테고리별 케이크 사진 조회 구현 (no-offset)

> ### Core Code

```java
. . .
	public List<CakeImageResponseParam> findCakeImagesByCursorAndCategory(Long cakeId, CakeDesignCategory category, int pageSize) {
		return queryFactory
			.select(Projections.constructor(CakeImageResponseParam.class,
				cakeShop.id,
				cake.id,
				cake.cakeImageUrl))
			.from(cake)
			.innerJoin(cake.cakeShop, cakeShop)
			.innerJoin(cakeCategory.cake, cake)
			.where(
				ltCakeId(cakeId),
				eqCategory(category))
			.limit(pageSize)
			.orderBy(cakeIdDesc())
			.fetch();
	}
. . .
```

> ### etc
