### PR TITLE
Refactor: TestWithDisplayName 어노테이션 구현 및 적용

### DIFF
--- a/cakk-api/src/main/java/com/cakk/api/service/cake/CakeService.java
+++ b/cakk-api/src/main/java/com/cakk/api/service/cake/CakeService.java
@@ -15,6 +15,6 @@ public class CakeService {
 	private final CakeReader cakeReader;
 
 	public CakeImageListResponse findCakeImagesByCursorAndCategory(final CakeSearchByCategoryRequest dto) {
-		return CakeImageListResponse.from(cakeReader.findCakeImagesByCursorAndCategory(dto.cakeId(), dto.category(), dto.pageSize()));
+		return CakeImageListResponse.from(cakeReader.searchCakeImagesByCursorAndCategory(dto.cakeId(), dto.category(), dto.pageSize()));
 	}
 }

--- a/cakk-api/src/test/java/com/cakk/api/ArchitectureTest.java
+++ b/cakk-api/src/test/java/com/cakk/api/ArchitectureTest.java
@@ -5,8 +5,8 @@ import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.*;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 
+import com.cakk.api.common.annotation.TestWithDisplayName;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import com.tngtech.archunit.core.importer.ImportOption;
@@ -24,8 +24,7 @@ class ArchitectureTest {
 			.importPackages("com.cakk");
 	}
 
-	@DisplayName("response 패키지 안에 있는 클래스들은 Response로 끝나야 한다.")
-	@Test
+	@TestWithDisplayName("response 패키지 안에 있는 클래스들은 Response로 끝나야 한다.")
 	void response() {
 		ArchRule rule = classes()
 			.that().resideInAPackage("..response")
@@ -36,8 +35,7 @@ class ArchitectureTest {
 	}
 
 	@Disabled
-	@DisplayName("Provider 클래스는 Service, Filter, Provider 클래스에만 의존해야 한다.")
-	@Test
+	@TestWithDisplayName("Provider 클래스는 Service, Filter, Provider 클래스에만 의존해야 한다.")
 	void providerDependency() {
 		ArchRule rule = classes()
 			.that().haveNameMatching(".*Provider")
@@ -49,8 +47,7 @@ class ArchitectureTest {
 		rule.check(javaClasses);
 	}
 
-	@DisplayName("Entity는 아무것도 의존하지 않는다.")
-	@Test
+	@TestWithDisplayName("Entity는 아무것도 의존하지 않는다.")
 	void entityNotDependency() {
 		ArchRule rule = classes()
 			.that()

--- a/cakk-api/src/test/java/com/cakk/api/common/annotation/MockCustomUser.java
+++ b/cakk-api/src/test/java/com/cakk/api/common/annotation/MockCustomUser.java
@@ -1,8 +1,9 @@
-package com.cakk.api.config;
+package com.cakk.api.common.annotation;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import org.springframework.security.test.context.support.WithSecurityContext;
+import com.cakk.api.common.config.WithMockCustomUserSecurityContextFactory;
 
 @Retention(RetentionPolicy.RUNTIME)
 @WithSecurityContext(factory = WithMockCustomUserSecurityContextFactory.class)

--- a/cakk-api/src/test/java/com/cakk/api/common/annotation/TestWithDisplayName.java
+++ b/cakk-api/src/test/java/com/cakk/api/common/annotation/TestWithDisplayName.java
@@ -1,0 +1,41 @@
+package com.cakk.api.common.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@Target({ElementType.ANNOTATION_TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Test
+@DisplayNameGeneration(TestWithDisplayName.TestDisplayNameGenerator.class)
+public @interface TestWithDisplayName {
+
+	String value() default "";
+
+	class TestDisplayNameGenerator extends DisplayNameGenerator.Standard {
+
+		@Override
+		public String generateDisplayNameForClass(Class<?> testClass) {
+			final TestWithDisplayName testWithDisplayName = testClass.getAnnotation(TestWithDisplayName.class);
+
+			if (testWithDisplayName != null && !testWithDisplayName.value().isEmpty()) {
+				return testWithDisplayName.value();
+			}
+
+			return super.generateDisplayNameForClass(testClass);
+		}
+
+		@Override
+		public String generateDisplayNameForMethod(Class<?> testClass, Method testMethod) {
+			return testMethod.getName();
+		}
+	}
+}

--- a/cakk-api/src/test/java/com/cakk/api/common/config/WithMockCustomUserSecurityContextFactory.java
+++ b/cakk-api/src/test/java/com/cakk/api/common/config/WithMockCustomUserSecurityContextFactory.java
@@ -1,4 +1,4 @@
-package com.cakk.api.config;
+package com.cakk.api.common.config;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -7,6 +7,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.test.context.support.WithSecurityContextFactory;
 import org.springframework.stereotype.Component;
 
+import com.cakk.api.common.annotation.MockCustomUser;
 import com.cakk.api.vo.OAuthUserDetails;
 import com.cakk.domain.entity.user.User;
 import com.cakk.domain.repository.reader.UserReader;

--- a/cakk-api/src/test/java/com/cakk/api/integration/cake/CakeIntegrationTest.java
+++ b/cakk-api/src/test/java/com/cakk/api/integration/cake/CakeIntegrationTest.java
@@ -3,7 +3,6 @@ package com.cakk.api.integration.cake;
 import static org.junit.Assert.*;
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.*;
 
-import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
@@ -13,6 +12,7 @@ import org.springframework.web.util.UriComponents;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import com.cakk.api.common.base.IntegrationTest;
+import com.cakk.api.common.annotation.TestWithDisplayName;
 import com.cakk.api.dto.response.cake.CakeImageListResponse;
 import com.cakk.common.enums.CakeDesignCategory;
 import com.cakk.common.enums.ReturnCode;
@@ -35,8 +35,8 @@ class CakeIntegrationTest extends IntegrationTest {
 	@Autowired
 	private CakeCategoryReader cakeCategoryReader;
 
-	@Test
-	void 카테고리로_케이크_이미지_조회에_성공한다() {
+	@TestWithDisplayName("카테고리로 첫 페이지 케이크 이미지 조회에 성공한다")
+	void searchByCategory1() {
 		// given
 		final String url = "%s%d%s/search/categories".formatted(BASE_URL, port, API_URL);
 		final UriComponents uriComponents = UriComponentsBuilder
@@ -65,8 +65,8 @@ class CakeIntegrationTest extends IntegrationTest {
 		});
 	}
 
-	@Test
-	void 카테고리로_다음_페이지_케이크_이미지_조회에_성공한다() {
+	@TestWithDisplayName("카테고리로 첫 페이지가 아닌 케이크 이미지 조회에 성공한다")
+	void searchByCategory2() {
 		// given
 		final String url = "%s%d%s/search/categories".formatted(BASE_URL, port, API_URL);
 		final UriComponents uriComponents = UriComponentsBuilder
@@ -96,8 +96,8 @@ class CakeIntegrationTest extends IntegrationTest {
 		});
 	}
 
-	@Test
-	void 카테고리로_케이크_이미지_조회_시_데이터가_없으면_빈_배열을_반환한다() {
+	@TestWithDisplayName("카테고리로 케이크 이미지 조회 시 데이터가 없으면 빈 배열을 반환한다")
+	void searchByCategory3() {
 		// given
 		final String url = "%s%d%s/search/categories".formatted(BASE_URL, port, API_URL);
 		final UriComponents uriComponents = UriComponentsBuilder

--- a/cakk-api/src/test/java/com/cakk/api/provider/JwtProviderTest.java
+++ b/cakk-api/src/test/java/com/cakk/api/provider/JwtProviderTest.java
@@ -9,7 +9,6 @@ import java.security.Key;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Value;
@@ -21,6 +20,7 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 
+import com.cakk.api.common.annotation.TestWithDisplayName;
 import com.cakk.api.common.base.ProviderTest;
 import com.cakk.api.config.JwtConfig;
 import com.cakk.api.provider.jwt.JwtProvider;
@@ -50,8 +50,7 @@ class JwtProviderTest extends ProviderTest {
 		ReflectionTestUtils.setField(jwtProvider, "key", Keys.hmacShaKeyFor(Decoders.BASE64.decode(SECRET_KEY)));
 	}
 
-	@DisplayName("토큰 생성에 성공한다.")
-	@Test
+	@TestWithDisplayName("토큰 생성에 성공한다.")
 	void generateToken1() {
 		// given
 		User user = fixtureMonkey.giveMeOne(User.class);
@@ -65,8 +64,7 @@ class JwtProviderTest extends ProviderTest {
 		Assertions.assertNotNull(jwt.grantType());
 	}
 
-	@DisplayName("User가 null인 경우, 토큰 생성에 실패한다.")
-	@Test
+	@TestWithDisplayName("User가 null인 경우, 토큰 생성에 실패한다.")
 	void generateToken2() {
 		// given
 		User user = null;
@@ -78,8 +76,7 @@ class JwtProviderTest extends ProviderTest {
 			EMPTY_USER.getCode());
 	}
 
-	@DisplayName("액세스 토큰으로부터 인증 정보를 가져온다.")
-	@Test
+	@TestWithDisplayName("액세스 토큰으로부터 인증 정보를 가져온다.")
 	void getAuthentication() {
 		// given
 		User user = fixtureMonkey.giveMeOne(User.class);
@@ -95,8 +92,7 @@ class JwtProviderTest extends ProviderTest {
 		Assertions.assertEquals(authentication.getAuthorities().toString(), "[%s]".formatted(USER.getSecurityRole()));
 	}
 
-	@DisplayName("토큰으로부터 Claim 정보를 가져온다.")
-	@Test
+	@TestWithDisplayName("토큰으로부터 Claim 정보를 가져온다.")
 	void parseClaims() {
 		// given
 		User user = fixtureMonkey.giveMeOne(User.class);

--- a/cakk-api/src/test/java/com/cakk/api/service/cake/CakeServiceTest.java
+++ b/cakk-api/src/test/java/com/cakk/api/service/cake/CakeServiceTest.java
@@ -33,7 +33,7 @@ class CakeServiceTest extends ServiceTest {
 		CakeSearchByCategoryRequest dto = new CakeSearchByCategoryRequest(null, CakeDesignCategory.FLOWER, 3);
 		List<CakeImageResponseParam> cakeImages = getConstructorMonkey().giveMe(CakeImageResponseParam.class, 3);
 
-		doReturn(cakeImages).when(cakeReader).findCakeImagesByCursorAndCategory(dto.cakeId(), dto.category(), dto.pageSize());
+		doReturn(cakeImages).when(cakeReader).searchCakeImagesByCursorAndCategory(dto.cakeId(), dto.category(), dto.pageSize());
 
 		// when
 		CakeImageListResponse result = cakeService.findCakeImagesByCursorAndCategory(dto);
@@ -42,7 +42,7 @@ class CakeServiceTest extends ServiceTest {
 		Assertions.assertEquals(cakeImages.size(), result.cakeImages().size());
 		Assertions.assertNotNull(result.lastCakeId());
 
-		verify(cakeReader).findCakeImagesByCursorAndCategory(dto.cakeId(), dto.category(), dto.pageSize());
+		verify(cakeReader).searchCakeImagesByCursorAndCategory(dto.cakeId(), dto.category(), dto.pageSize());
 	}
 
 	@TestWithDisplayName("카테고리에 해당하는 케이크가 없을 시 빈 배열을 리턴한다.")
@@ -51,7 +51,7 @@ class CakeServiceTest extends ServiceTest {
 		CakeSearchByCategoryRequest dto = new CakeSearchByCategoryRequest(null, CakeDesignCategory.FLOWER, 3);
 		List<CakeImageResponseParam> cakeImages = getConstructorMonkey().giveMe(CakeImageResponseParam.class, 0);
 
-		doReturn(cakeImages).when(cakeReader).findCakeImagesByCursorAndCategory(dto.cakeId(), dto.category(), dto.pageSize());
+		doReturn(cakeImages).when(cakeReader).searchCakeImagesByCursorAndCategory(dto.cakeId(), dto.category(), dto.pageSize());
 
 		// when
 		CakeImageListResponse result = cakeService.findCakeImagesByCursorAndCategory(dto);
@@ -60,6 +60,6 @@ class CakeServiceTest extends ServiceTest {
 		Assertions.assertEquals(cakeImages.size(), result.cakeImages().size());
 		Assertions.assertNull(result.lastCakeId());
 
-		verify(cakeReader).findCakeImagesByCursorAndCategory(dto.cakeId(), dto.category(), dto.pageSize());
+		verify(cakeReader).searchCakeImagesByCursorAndCategory(dto.cakeId(), dto.category(), dto.pageSize());
 	}
 }

--- a/cakk-api/src/test/java/com/cakk/api/service/cake/CakeServiceTest.java
+++ b/cakk-api/src/test/java/com/cakk/api/service/cake/CakeServiceTest.java
@@ -6,11 +6,11 @@ import java.util.List;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 
+import com.cakk.api.common.annotation.TestWithDisplayName;
 import com.cakk.api.common.base.ServiceTest;
 import com.cakk.api.dto.request.cake.CakeSearchByCategoryRequest;
 import com.cakk.api.dto.response.cake.CakeImageListResponse;
@@ -27,8 +27,8 @@ class CakeServiceTest extends ServiceTest {
 	@Mock
 	private CakeReader cakeReader;
 
-	@Test
-	void 카테고리에_해당하는_케이크_목록을_조회한다() {
+	@TestWithDisplayName("카테고리에 해당하는 케이크 목록을 조회한다")
+	void findCakeImagesByCursorAndCategory1() {
 		// given
 		CakeSearchByCategoryRequest dto = new CakeSearchByCategoryRequest(null, CakeDesignCategory.FLOWER, 3);
 		List<CakeImageResponseParam> cakeImages = getConstructorMonkey().giveMe(CakeImageResponseParam.class, 3);
@@ -45,8 +45,8 @@ class CakeServiceTest extends ServiceTest {
 		verify(cakeReader).findCakeImagesByCursorAndCategory(dto.cakeId(), dto.category(), dto.pageSize());
 	}
 
-	@Test
-	void 카테고리에_해당하는_케이크가_없을_시_빈_배열을_리턴한다() {
+	@TestWithDisplayName("카테고리에 해당하는 케이크가 없을 시 빈 배열을 리턴한다.")
+	void findCakeImagesByCursorAndCategory2() {
 		// given
 		CakeSearchByCategoryRequest dto = new CakeSearchByCategoryRequest(null, CakeDesignCategory.FLOWER, 3);
 		List<CakeImageResponseParam> cakeImages = getConstructorMonkey().giveMe(CakeImageResponseParam.class, 0);

--- a/cakk-api/src/test/java/com/cakk/api/service/user/UserServiceTest.java
+++ b/cakk-api/src/test/java/com/cakk/api/service/user/UserServiceTest.java
@@ -3,19 +3,18 @@ package com.cakk.api.service.user;
 import static org.mockito.Mockito.*;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 
 import net.jqwik.api.Arbitraries;
 
+import com.cakk.api.common.annotation.TestWithDisplayName;
 import com.cakk.api.common.base.ServiceTest;
 import com.cakk.api.dto.request.user.UserSignInRequest;
 import com.cakk.api.dto.request.user.UserSignUpRequest;
 import com.cakk.api.dto.response.user.JwtResponse;
 import com.cakk.api.factory.OidcProviderFactory;
 import com.cakk.api.provider.jwt.JwtProvider;
-import com.cakk.api.service.user.UserService;
 import com.cakk.api.vo.JsonWebToken;
 import com.cakk.common.enums.ReturnCode;
 import com.cakk.common.exception.CakkException;
@@ -41,8 +40,8 @@ class UserServiceTest extends ServiceTest {
 	@Mock
 	private UserWriter userWriter;
 
-	@Test
-	void 회원가입에_성공한다() {
+	@TestWithDisplayName("회원가입에 성공한다")
+	void signUp1() {
 		// given
 		UserSignUpRequest dto = getConstructorMonkey().giveMeOne(UserSignUpRequest.class);
 		User user = getReflectionMonkey().giveMeBuilder(User.class)
@@ -73,8 +72,8 @@ class UserServiceTest extends ServiceTest {
 		verify(jwtProvider, times(1)).generateToken(user);
 	}
 
-	@Test
-	void 만료된_id_token이라면_회원가입_시_에러를_던진다() {
+	@TestWithDisplayName("만료된 id token이라면 회원가입 시 에러를 던진다")
+	void signUp2() {
 		// given
 		UserSignUpRequest dto = getConstructorMonkey().giveMeOne(UserSignUpRequest.class);
 		User user = getReflectionMonkey().giveMeBuilder(User.class)
@@ -96,8 +95,8 @@ class UserServiceTest extends ServiceTest {
 		verify(jwtProvider, times(0)).generateToken(user);
 	}
 
-	@Test
-	void 로그인에_성공한다() {
+	@TestWithDisplayName("로그인에 성공한다.")
+	void signIn() {
 		// given
 		UserSignInRequest dto = getConstructorMonkey().giveMeOne(UserSignInRequest.class);
 		String providerId = Arbitraries.strings().alpha().ofMinLength(10).ofMaxLength(20).sample();
@@ -129,8 +128,8 @@ class UserServiceTest extends ServiceTest {
 		verify(jwtProvider, times(1)).generateToken(user);
 	}
 
-	@Test
-	void 제공자_id에_해당하는_유저가_없다면_로그인_시_에러를_던진다() {
+	@TestWithDisplayName("제공자 id에 해당하는 유저가 없다면 로그인 시 에러를 던진다")
+	void signIn2() {
 		// given
 		UserSignInRequest dto = getConstructorMonkey().giveMeOne(UserSignInRequest.class);
 		String providerId = Arbitraries.strings().alpha().ofMinLength(10).ofMaxLength(20).sample();

--- a/cakk-domain/src/main/java/com/cakk/domain/repository/query/CakeQueryRepository.java
+++ b/cakk-domain/src/main/java/com/cakk/domain/repository/query/CakeQueryRepository.java
@@ -25,7 +25,7 @@ public class CakeQueryRepository {
 
 	private final JPAQueryFactory queryFactory;
 
-	public List<CakeImageResponseParam> findCakeImagesByCursorAndCategory(Long cakeId, CakeDesignCategory category, int pageSize) {
+	public List<CakeImageResponseParam> searchCakeImagesByCursorAndCategory(Long cakeId, CakeDesignCategory category, int pageSize) {
 		return queryFactory
 			.select(Projections.constructor(CakeImageResponseParam.class,
 				cakeShop.id,

--- a/cakk-domain/src/main/java/com/cakk/domain/repository/reader/CakeReader.java
+++ b/cakk-domain/src/main/java/com/cakk/domain/repository/reader/CakeReader.java
@@ -24,7 +24,7 @@ public class CakeReader {
 		return cakeJpaRepository.findById(cakeId).orElseThrow(() -> new CakkException(ReturnCode.NOT_EXIST_CAKE));
 	}
 
-	public List<CakeImageResponseParam> findCakeImagesByCursorAndCategory(Long cakeId, CakeDesignCategory category, int pageSize) {
-		return cakeQueryRepository.findCakeImagesByCursorAndCategory(cakeId, category, pageSize);
+	public List<CakeImageResponseParam> searchCakeImagesByCursorAndCategory(Long cakeId, CakeDesignCategory category, int pageSize) {
+		return cakeQueryRepository.searchCakeImagesByCursorAndCategory(cakeId, category, pageSize);
 	}
 }


### PR DESCRIPTION
> ### Issue Number

#34

> ### Description

기존, 메서드명으로 테스트 케이스 네이밍을 했는데, @DisplayName으로 명시하기로 결정돼 코드를 간소화 하기 위해 @TestWithDisplayName 어노테이션을 구현하였습니다.

> ### Core Code

```java
@TestWithDisplayName("카테고리에 해당하는 케이크 목록을 조회한다")
void findCakeImagesByCursorAndCategory1() {
. . .
```

> ### etc
