### PR TITLE
Feature: 케이크 샵 간단조회 API 구현

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,6 @@ on:
     branches:
       - develop
       - master
-  push:
-    branches:
-      - develop
-      - master
 
 permissions: write-all
 

--- a/.github/workflows/prod-app-api-cd.yml
+++ b/.github/workflows/prod-app-api-cd.yml
@@ -4,10 +4,10 @@ on:
   push:
     branches:
       - master
-#    paths:
-#      - cakk-api/**
-#      - cakk-domain/**
-#      - cakk-common/**
+    paths:
+      - cakk-api/**
+      - cakk-domain/**
+      - cakk-common/**
 
 permissions: write-all
 

--- a/cakk-api/src/main/java/com/cakk/api/controller/shop/ShopController.java
+++ b/cakk-api/src/main/java/com/cakk/api/controller/shop/ShopController.java
@@ -2,7 +2,9 @@ package com.cakk.api.controller.shop;
 
 import jakarta.validation.Valid;
 
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -16,6 +18,7 @@ import com.cakk.api.dto.request.shop.PromotionRequest;
 import com.cakk.api.dto.request.user.CertificationRequest;
 import com.cakk.api.service.shop.ShopService;
 import com.cakk.common.response.ApiResponse;
+import com.cakk.domain.dto.param.shop.CakeShopSimpleResponse;
 import com.cakk.domain.entity.user.User;
 
 @RestController
@@ -47,6 +50,14 @@ public class ShopController {
 	) {
 		shopService.promoteUserToBusinessOwner(promotionRequest);
 		return ApiResponse.success();
+	}
+
+	@GetMapping("/{cakeShopId}/simple")
+	public ApiResponse<CakeShopSimpleResponse> simple(
+		@PathVariable Long cakeShopId
+	) {
+		final CakeShopSimpleResponse response = shopService.searchSimpleById(cakeShopId);
+		return ApiResponse.success(response);
 	}
 
 }

--- a/cakk-api/src/test/java/com/cakk/api/integration/shop/ShopIntegrationTest.java
+++ b/cakk-api/src/test/java/com/cakk/api/integration/shop/ShopIntegrationTest.java
@@ -1,0 +1,81 @@
+package com.cakk.api.integration.shop;
+
+import static org.junit.Assert.*;
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.*;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.SqlGroup;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import com.cakk.api.common.annotation.TestWithDisplayName;
+import com.cakk.api.common.base.IntegrationTest;
+import com.cakk.common.enums.ReturnCode;
+import com.cakk.common.response.ApiResponse;
+import com.cakk.domain.dto.param.shop.CakeShopSimpleResponse;
+import com.cakk.domain.entity.shop.CakeShop;
+import com.cakk.domain.repository.reader.CakeShopReader;
+
+@SqlGroup({
+	@Sql(scripts = "/sql/insert-cake-shop.sql", executionPhase = BEFORE_TEST_METHOD),
+	@Sql(scripts = "/sql/delete-all.sql", executionPhase = AFTER_TEST_METHOD)
+})
+public class ShopIntegrationTest extends IntegrationTest {
+
+	private static final String API_URL = "/api/v1/shops";
+
+	@Autowired
+	private CakeShopReader cakeShopReader;
+
+	@TestWithDisplayName("케이크 샵을 간단 조회에 성공한다.")
+	void simple1() {
+		final String url = "%s%d%s".formatted(BASE_URL, port, API_URL);
+		final Long cakeShopId = 1L;
+		final UriComponents uriComponents = UriComponentsBuilder
+			.fromUriString(url)
+			.path("/{cakeShopId}/simple")
+			.buildAndExpand(cakeShopId);
+
+		// when
+		final ResponseEntity<ApiResponse> responseEntity = restTemplate.getForEntity(uriComponents.toUriString(), ApiResponse.class);
+
+		// then
+		final ApiResponse response = objectMapper.convertValue(responseEntity.getBody(), ApiResponse.class);
+		final CakeShopSimpleResponse data = objectMapper.convertValue(response.getData(), CakeShopSimpleResponse.class);
+
+		assertEquals(HttpStatusCode.valueOf(200), responseEntity.getStatusCode());
+		assertEquals(ReturnCode.SUCCESS.getCode(), response.getReturnCode());
+		assertEquals(ReturnCode.SUCCESS.getMessage(), response.getReturnMessage());
+
+		final CakeShop cakeShop = cakeShopReader.findById(cakeShopId);
+		assertEquals(cakeShop.getId(), data.cakeShopId());
+		assertEquals(cakeShop.getThumbnailUrl(), data.thumbnailUrl());
+		assertEquals(cakeShop.getShopName(), data.cakeShopName());
+		assertEquals(cakeShop.getShopBio(), data.cakeShopBio());
+	}
+
+	@TestWithDisplayName("없는 케이크 샵일 경우, 간단 조회에 실패한다.")
+	void simple2() {
+		final String url = "%s%d%s".formatted(BASE_URL, port, API_URL);
+		final Long cakeShopId = 1000L;
+		final UriComponents uriComponents = UriComponentsBuilder
+			.fromUriString(url)
+			.path("/{cakeShopId}/simple")
+			.buildAndExpand(cakeShopId);
+
+		// when
+		final ResponseEntity<ApiResponse> responseEntity = restTemplate.getForEntity(uriComponents.toUriString(), ApiResponse.class);
+
+		// then
+		final ApiResponse response = objectMapper.convertValue(responseEntity.getBody(), ApiResponse.class);
+		final CakeShopSimpleResponse data = objectMapper.convertValue(response.getData(), CakeShopSimpleResponse.class);
+
+		assertEquals(HttpStatusCode.valueOf(400), responseEntity.getStatusCode());
+		assertEquals(ReturnCode.NOT_EXIST_CAKE_SHOP.getCode(), response.getReturnCode());
+		assertEquals(ReturnCode.NOT_EXIST_CAKE_SHOP.getMessage(), response.getReturnMessage());
+	}
+
+}

--- a/cakk-api/src/test/resources/sql/insert-cake-shop.sql
+++ b/cakk-api/src/test/resources/sql/insert-cake-shop.sql
@@ -1,0 +1,5 @@
+insert into cake_shop (shop_id, thumbnail_url, shop_name, shop_bio, shop_description, latitude, longitude, like_count, linked_flag,
+                       created_at, updated_at)
+values (1, 'thumbnail_url1', '케이크 맛집1', '케이크 맛집입니다.', '케이크 맛집입니다.', 37.123456, 127.123456, 0, false, now(), now()),
+       (2, 'thumbnail_url2', '케이크 맛집2', '케이크 맛집입니다.', '케이크 맛집입니다.', 38.123456, 128.123456, 0, false, now(), now()),
+       (3, 'thumbnail_url3', '케이크 맛집3', '케이크 맛집입니다.', '케이크 맛집입니다.', 39.123456, 129.123456, 0, false, now(), now());


### PR DESCRIPTION
> ### Issue Number

#23

> ### Description

케이크 샵 간단조회 API를 구현하고, 통합 테스트를 작성했습니다. id 조회다보니 TC는 2건입니다.

> ### Core Code

```java
. . .
	@GetMapping("/{cakeShopId}/simple")
	public ApiResponse<CakeShopSimpleResponse> simple(
		@PathVariable Long cakeShopId
	) {
		final CakeShopSimpleResponse response = shopService.searchSimpleById(cakeShopId);
		return ApiResponse.success(response);
	}
. . .
```

> ### etc
