### PR TITLE
Feature: 케이크 샵 상세조회 API 구현

### DIFF
--- a/cakk-api/src/main/java/com/cakk/api/controller/shop/ShopController.java
+++ b/cakk-api/src/main/java/com/cakk/api/controller/shop/ShopController.java
@@ -16,9 +16,10 @@ import com.cakk.api.annotation.SignInUser;
 import com.cakk.api.dto.request.shop.CreateShopRequest;
 import com.cakk.api.dto.request.shop.PromotionRequest;
 import com.cakk.api.dto.request.user.CertificationRequest;
+import com.cakk.api.dto.response.shop.CakeShopDetailResponse;
+import com.cakk.api.dto.response.shop.CakeShopSimpleResponse;
 import com.cakk.api.service.shop.ShopService;
 import com.cakk.common.response.ApiResponse;
-import com.cakk.domain.dto.param.shop.CakeShopSimpleResponse;
 import com.cakk.domain.entity.user.User;
 
 @RestController
@@ -60,4 +61,11 @@ public class ShopController {
 		return ApiResponse.success(response);
 	}
 
+	@GetMapping("/{cakeShopId}")
+	public ApiResponse<CakeShopDetailResponse> detail(
+		@PathVariable Long cakeShopId
+	) {
+		final CakeShopDetailResponse response = shopService.searchDetailById(cakeShopId);
+		return ApiResponse.success(response);
+	}
 }

--- a/cakk-api/src/main/java/com/cakk/api/dto/response/shop/CakeShopDetailResponse.java
+++ b/cakk-api/src/main/java/com/cakk/api/dto/response/shop/CakeShopDetailResponse.java
@@ -1,6 +1,6 @@
 package com.cakk.api.dto.response.shop;
 
-import java.util.List;
+import java.util.Set;
 
 import lombok.Builder;
 
@@ -11,22 +11,22 @@ import com.cakk.domain.dto.param.shop.CakeShopLinkParam;
 @Builder
 public record CakeShopDetailResponse(
 	Long cakeShopId,
-	String shopName,
+	String cakeShopName,
 	String thumbnailUrl,
-	String shopBio,
-	String shopDescription,
-	List<Days> operationDay,
-	List<CakeShopLinkParam> links
+	String cakeShopBio,
+	String cakeShopDescription,
+	Set<Days> operationDays,
+	Set<CakeShopLinkParam> links
 ) {
 
 	public static CakeShopDetailResponse from(CakeShopDetailParam param) {
 		return CakeShopDetailResponse.builder()
 			.cakeShopId(param.cakeShopId())
-			.shopName(param.shopName())
+			.cakeShopName(param.shopName())
 			.thumbnailUrl(param.thumbnailUrl())
-			.shopBio(param.shopBio())
-			.shopDescription(param.shopDescription())
-			.operationDay(param.operationDay())
+			.cakeShopBio(param.shopBio())
+			.cakeShopDescription(param.shopDescription())
+			.operationDays(param.operationDays())
 			.links(param.links())
 			.build();
 	}

--- a/cakk-api/src/main/java/com/cakk/api/dto/response/shop/CakeShopDetailResponse.java
+++ b/cakk-api/src/main/java/com/cakk/api/dto/response/shop/CakeShopDetailResponse.java
@@ -5,7 +5,6 @@ import java.util.Set;
 import lombok.Builder;
 
 import com.cakk.common.enums.Days;
-import com.cakk.domain.dto.param.shop.CakeShopDetailParam;
 import com.cakk.domain.dto.param.shop.CakeShopLinkParam;
 
 @Builder
@@ -18,16 +17,4 @@ public record CakeShopDetailResponse(
 	Set<Days> operationDays,
 	Set<CakeShopLinkParam> links
 ) {
-
-	public static CakeShopDetailResponse from(CakeShopDetailParam param) {
-		return CakeShopDetailResponse.builder()
-			.cakeShopId(param.cakeShopId())
-			.cakeShopName(param.shopName())
-			.thumbnailUrl(param.thumbnailUrl())
-			.cakeShopBio(param.shopBio())
-			.cakeShopDescription(param.shopDescription())
-			.operationDays(param.operationDays())
-			.links(param.links())
-			.build();
-	}
 }

--- a/cakk-api/src/main/java/com/cakk/api/dto/response/shop/CakeShopSimpleResponse.java
+++ b/cakk-api/src/main/java/com/cakk/api/dto/response/shop/CakeShopSimpleResponse.java
@@ -2,8 +2,6 @@ package com.cakk.api.dto.response.shop;
 
 import lombok.Builder;
 
-import com.cakk.domain.dto.param.shop.CakeShopSimpleParam;
-
 @Builder
 public record CakeShopSimpleResponse(
 	Long cakeShopId,
@@ -11,13 +9,4 @@ public record CakeShopSimpleResponse(
 	String cakeShopName,
 	String cakeShopBio
 ) {
-
-	public static CakeShopSimpleResponse from(CakeShopSimpleParam param) {
-		return CakeShopSimpleResponse.builder()
-			.cakeShopId(param.cakeShopId())
-			.thumbnailUrl(param.thumbnailUrl())
-			.cakeShopName(param.cakeShopName())
-			.cakeShopBio(param.cakeShopBio())
-			.build();
-	}
 }

--- a/cakk-api/src/main/java/com/cakk/api/dto/response/shop/CakeShopSimpleResponse.java
+++ b/cakk-api/src/main/java/com/cakk/api/dto/response/shop/CakeShopSimpleResponse.java
@@ -1,0 +1,23 @@
+package com.cakk.api.dto.response.shop;
+
+import lombok.Builder;
+
+import com.cakk.domain.dto.param.shop.CakeShopSimpleParam;
+
+@Builder
+public record CakeShopSimpleResponse(
+	Long cakeShopId,
+	String thumbnailUrl,
+	String cakeShopName,
+	String cakeShopBio
+) {
+
+	public static CakeShopSimpleResponse from(CakeShopSimpleParam param) {
+		return CakeShopSimpleResponse.builder()
+			.cakeShopId(param.cakeShopId())
+			.thumbnailUrl(param.thumbnailUrl())
+			.cakeShopName(param.cakeShopName())
+			.cakeShopBio(param.cakeShopBio())
+			.build();
+	}
+}

--- a/cakk-api/src/main/java/com/cakk/api/mapper/ShopMapper.java
+++ b/cakk-api/src/main/java/com/cakk/api/mapper/ShopMapper.java
@@ -8,7 +8,11 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 import com.cakk.api.dto.request.shop.CreateShopRequest;
+import com.cakk.api.dto.response.shop.CakeShopDetailResponse;
+import com.cakk.api.dto.response.shop.CakeShopSimpleResponse;
 import com.cakk.common.enums.Days;
+import com.cakk.domain.dto.param.shop.CakeShopDetailParam;
+import com.cakk.domain.dto.param.shop.CakeShopSimpleParam;
 import com.cakk.domain.entity.shop.CakeShop;
 import com.cakk.domain.entity.shop.CakeShopOperation;
 import com.cakk.domain.entity.user.BusinessInformation;
@@ -58,4 +62,24 @@ public class ShopMapper {
 		return cakeShopOperations;
 	}
 
+	public static CakeShopSimpleResponse cakeShopSimpleResponseFromParam(CakeShopSimpleParam param) {
+		return CakeShopSimpleResponse.builder()
+			.cakeShopId(param.cakeShopId())
+			.thumbnailUrl(param.thumbnailUrl())
+			.cakeShopName(param.cakeShopName())
+			.cakeShopBio(param.cakeShopBio())
+			.build();
+	}
+
+	public static CakeShopDetailResponse cakeShopDetailResponseFromParam(CakeShopDetailParam param) {
+		return CakeShopDetailResponse.builder()
+			.cakeShopId(param.cakeShopId())
+			.cakeShopName(param.shopName())
+			.thumbnailUrl(param.thumbnailUrl())
+			.cakeShopBio(param.shopBio())
+			.cakeShopDescription(param.shopDescription())
+			.operationDays(param.operationDays())
+			.links(param.links())
+			.build();
+	}
 }

--- a/cakk-api/src/main/java/com/cakk/api/service/shop/ShopService.java
+++ b/cakk-api/src/main/java/com/cakk/api/service/shop/ShopService.java
@@ -11,9 +11,10 @@ import lombok.RequiredArgsConstructor;
 import com.cakk.api.dto.request.shop.CreateShopRequest;
 import com.cakk.api.dto.request.shop.PromotionRequest;
 import com.cakk.api.dto.response.shop.CakeShopDetailResponse;
+import com.cakk.api.dto.response.shop.CakeShopSimpleResponse;
 import com.cakk.api.mapper.ShopMapper;
 import com.cakk.domain.dto.param.shop.CakeShopDetailParam;
-import com.cakk.domain.dto.param.shop.CakeShopSimpleResponse;
+import com.cakk.domain.dto.param.shop.CakeShopSimpleParam;
 import com.cakk.domain.dto.param.user.CertificationParam;
 import com.cakk.domain.entity.shop.CakeShop;
 import com.cakk.domain.entity.shop.CakeShopOperation;
@@ -69,7 +70,9 @@ public class ShopService {
 
 	@Transactional(readOnly = true)
 	public CakeShopSimpleResponse searchSimpleById(final Long cakeShopId) {
-		return cakeShopReader.searchSimpleById(cakeShopId);
+		final CakeShopSimpleParam cakeShop = cakeShopReader.searchSimpleById(cakeShopId);
+
+		return CakeShopSimpleResponse.from(cakeShop);
 	}
 
 	@Transactional(readOnly = true)

--- a/cakk-api/src/main/java/com/cakk/api/service/shop/ShopService.java
+++ b/cakk-api/src/main/java/com/cakk/api/service/shop/ShopService.java
@@ -72,13 +72,13 @@ public class ShopService {
 	public CakeShopSimpleResponse searchSimpleById(final Long cakeShopId) {
 		final CakeShopSimpleParam cakeShop = cakeShopReader.searchSimpleById(cakeShopId);
 
-		return CakeShopSimpleResponse.from(cakeShop);
+		return ShopMapper.cakeShopSimpleResponseFromParam(cakeShop);
 	}
 
 	@Transactional(readOnly = true)
 	public CakeShopDetailResponse searchDetailById(final Long cakeShopId) {
 		final CakeShopDetailParam cakeShop = cakeShopReader.searchDetailById(cakeShopId);
 
-		return CakeShopDetailResponse.from(cakeShop);
+		return ShopMapper.cakeShopDetailResponseFromParam(cakeShop);
 	}
 }

--- a/cakk-api/src/test/java/com/cakk/api/integration/shop/ShopIntegrationTest.java
+++ b/cakk-api/src/test/java/com/cakk/api/integration/shop/ShopIntegrationTest.java
@@ -3,7 +3,6 @@ package com.cakk.api.integration.shop;
 import static org.junit.Assert.*;
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.*;
 
-import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,7 +22,6 @@ import com.cakk.common.enums.ReturnCode;
 import com.cakk.common.response.ApiResponse;
 import com.cakk.domain.dto.param.shop.CakeShopLinkParam;
 import com.cakk.domain.entity.shop.CakeShop;
-import com.cakk.domain.entity.shop.CakeShopLink;
 import com.cakk.domain.entity.shop.CakeShopOperation;
 import com.cakk.domain.repository.reader.CakeShopLinkReader;
 import com.cakk.domain.repository.reader.CakeShopOperationReader;

--- a/cakk-api/src/test/java/com/cakk/api/integration/shop/ShopIntegrationTest.java
+++ b/cakk-api/src/test/java/com/cakk/api/integration/shop/ShopIntegrationTest.java
@@ -15,7 +15,7 @@ import com.cakk.api.common.annotation.TestWithDisplayName;
 import com.cakk.api.common.base.IntegrationTest;
 import com.cakk.common.enums.ReturnCode;
 import com.cakk.common.response.ApiResponse;
-import com.cakk.domain.dto.param.shop.CakeShopSimpleResponse;
+import com.cakk.domain.dto.param.shop.CakeShopSimpleParam;
 import com.cakk.domain.entity.shop.CakeShop;
 import com.cakk.domain.repository.reader.CakeShopReader;
 
@@ -44,7 +44,7 @@ public class ShopIntegrationTest extends IntegrationTest {
 
 		// then
 		final ApiResponse response = objectMapper.convertValue(responseEntity.getBody(), ApiResponse.class);
-		final CakeShopSimpleResponse data = objectMapper.convertValue(response.getData(), CakeShopSimpleResponse.class);
+		final CakeShopSimpleParam data = objectMapper.convertValue(response.getData(), CakeShopSimpleParam.class);
 
 		assertEquals(HttpStatusCode.valueOf(200), responseEntity.getStatusCode());
 		assertEquals(ReturnCode.SUCCESS.getCode(), response.getReturnCode());
@@ -71,7 +71,7 @@ public class ShopIntegrationTest extends IntegrationTest {
 
 		// then
 		final ApiResponse response = objectMapper.convertValue(responseEntity.getBody(), ApiResponse.class);
-		final CakeShopSimpleResponse data = objectMapper.convertValue(response.getData(), CakeShopSimpleResponse.class);
+		final CakeShopSimpleParam data = objectMapper.convertValue(response.getData(), CakeShopSimpleParam.class);
 
 		assertEquals(HttpStatusCode.valueOf(400), responseEntity.getStatusCode());
 		assertEquals(ReturnCode.NOT_EXIST_CAKE_SHOP.getCode(), response.getReturnCode());

--- a/cakk-api/src/test/java/com/cakk/api/integration/shop/ShopIntegrationTest.java
+++ b/cakk-api/src/test/java/com/cakk/api/integration/shop/ShopIntegrationTest.java
@@ -3,6 +3,9 @@ package com.cakk.api.integration.shop;
 import static org.junit.Assert.*;
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.*;
 
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
@@ -13,10 +16,17 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 import com.cakk.api.common.annotation.TestWithDisplayName;
 import com.cakk.api.common.base.IntegrationTest;
+import com.cakk.api.dto.response.shop.CakeShopDetailResponse;
+import com.cakk.api.dto.response.shop.CakeShopSimpleResponse;
+import com.cakk.common.enums.Days;
 import com.cakk.common.enums.ReturnCode;
 import com.cakk.common.response.ApiResponse;
-import com.cakk.domain.dto.param.shop.CakeShopSimpleParam;
+import com.cakk.domain.dto.param.shop.CakeShopLinkParam;
 import com.cakk.domain.entity.shop.CakeShop;
+import com.cakk.domain.entity.shop.CakeShopLink;
+import com.cakk.domain.entity.shop.CakeShopOperation;
+import com.cakk.domain.repository.reader.CakeShopLinkReader;
+import com.cakk.domain.repository.reader.CakeShopOperationReader;
 import com.cakk.domain.repository.reader.CakeShopReader;
 
 @SqlGroup({
@@ -29,6 +39,12 @@ public class ShopIntegrationTest extends IntegrationTest {
 
 	@Autowired
 	private CakeShopReader cakeShopReader;
+
+	@Autowired
+	private CakeShopOperationReader cakeShopOperationReader;
+
+	@Autowired
+	private CakeShopLinkReader cakeShopLinkReader;
 
 	@TestWithDisplayName("케이크 샵을 간단 조회에 성공한다.")
 	void simple1() {
@@ -44,7 +60,7 @@ public class ShopIntegrationTest extends IntegrationTest {
 
 		// then
 		final ApiResponse response = objectMapper.convertValue(responseEntity.getBody(), ApiResponse.class);
-		final CakeShopSimpleParam data = objectMapper.convertValue(response.getData(), CakeShopSimpleParam.class);
+		final CakeShopSimpleResponse data = objectMapper.convertValue(response.getData(), CakeShopSimpleResponse.class);
 
 		assertEquals(HttpStatusCode.valueOf(200), responseEntity.getStatusCode());
 		assertEquals(ReturnCode.SUCCESS.getCode(), response.getReturnCode());
@@ -71,7 +87,64 @@ public class ShopIntegrationTest extends IntegrationTest {
 
 		// then
 		final ApiResponse response = objectMapper.convertValue(responseEntity.getBody(), ApiResponse.class);
-		final CakeShopSimpleParam data = objectMapper.convertValue(response.getData(), CakeShopSimpleParam.class);
+
+		assertEquals(HttpStatusCode.valueOf(400), responseEntity.getStatusCode());
+		assertEquals(ReturnCode.NOT_EXIST_CAKE_SHOP.getCode(), response.getReturnCode());
+		assertEquals(ReturnCode.NOT_EXIST_CAKE_SHOP.getMessage(), response.getReturnMessage());
+	}
+
+	@TestWithDisplayName("케이크 샵을 상세 조회에 성공한다.")
+	void detail1() {
+		final String url = "%s%d%s".formatted(BASE_URL, port, API_URL);
+		final Long cakeShopId = 1L;
+		final UriComponents uriComponents = UriComponentsBuilder
+			.fromUriString(url)
+			.path("/{cakeShopId}")
+			.buildAndExpand(cakeShopId);
+
+		// when
+		final ResponseEntity<ApiResponse> responseEntity = restTemplate.getForEntity(uriComponents.toUriString(), ApiResponse.class);
+
+		// then
+		final ApiResponse response = objectMapper.convertValue(responseEntity.getBody(), ApiResponse.class);
+		final CakeShopDetailResponse data = objectMapper.convertValue(response.getData(), CakeShopDetailResponse.class);
+
+		assertEquals(HttpStatusCode.valueOf(200), responseEntity.getStatusCode());
+		assertEquals(ReturnCode.SUCCESS.getCode(), response.getReturnCode());
+		assertEquals(ReturnCode.SUCCESS.getMessage(), response.getReturnMessage());
+
+		final CakeShop cakeShop = cakeShopReader.findById(cakeShopId);
+		assertEquals(cakeShop.getId(), data.cakeShopId());
+		assertEquals(cakeShop.getThumbnailUrl(), data.thumbnailUrl());
+		assertEquals(cakeShop.getShopName(), data.cakeShopName());
+		assertEquals(cakeShop.getShopBio(), data.cakeShopBio());
+		assertEquals(cakeShop.getShopDescription(), data.cakeShopDescription());
+
+		final Set<Days> cakeShopOperations = cakeShopOperationReader.findAllByCakeShopId(cakeShopId).stream()
+			.map(CakeShopOperation::getOperationDay)
+			.collect(Collectors.toSet());
+		assertEquals(cakeShopOperations, data.operationDays());
+
+		final Set<CakeShopLinkParam> cakeShopLinks = cakeShopLinkReader.findAllByCakeShopId(cakeShopId).stream()
+			.map((it) -> new CakeShopLinkParam(it.getLinkKind(), it.getLinkPath()))
+			.collect(Collectors.toSet());
+		assertEquals(cakeShopLinks, data.links());
+	}
+
+	@TestWithDisplayName("없는 케이크 샵일 경우, 상세 조회에 실패한다.")
+	void detail2() {
+		final String url = "%s%d%s".formatted(BASE_URL, port, API_URL);
+		final Long cakeShopId = 1000L;
+		final UriComponents uriComponents = UriComponentsBuilder
+			.fromUriString(url)
+			.path("/{cakeShopId}")
+			.buildAndExpand(cakeShopId);
+
+		// when
+		final ResponseEntity<ApiResponse> responseEntity = restTemplate.getForEntity(uriComponents.toUriString(), ApiResponse.class);
+
+		// then
+		final ApiResponse response = objectMapper.convertValue(responseEntity.getBody(), ApiResponse.class);
 
 		assertEquals(HttpStatusCode.valueOf(400), responseEntity.getStatusCode());
 		assertEquals(ReturnCode.NOT_EXIST_CAKE_SHOP.getCode(), response.getReturnCode());

--- a/cakk-api/src/test/java/com/cakk/api/service/shop/ShopServiceTest.java
+++ b/cakk-api/src/test/java/com/cakk/api/service/shop/ShopServiceTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.*;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
-import java.util.List;
+import java.util.Set;
 
 import org.junit.jupiter.api.DisplayName;
 import org.mockito.InjectMocks;
@@ -91,8 +91,8 @@ public class ShopServiceTest extends ServiceTest {
 			.set("thumbnailUrl", Arbitraries.strings().alpha().ofMinLength(100).ofMaxLength(200))
 			.set("shopBio", Arbitraries.strings().alpha().ofMinLength(1).ofMaxLength(40))
 			.set("shopDescription", Arbitraries.strings().alpha().ofMinLength(1).ofMaxLength(500))
-			.set("operationDays", List.of())
-			.set("links", List.of())
+			.set("operationDays", Set.of())
+			.set("links", Set.of())
 			.sample();
 
 		doReturn(param).when(cakeShopReader).searchDetailById(cakeShopId);

--- a/cakk-api/src/test/java/com/cakk/api/service/shop/ShopServiceTest.java
+++ b/cakk-api/src/test/java/com/cakk/api/service/shop/ShopServiceTest.java
@@ -5,20 +5,22 @@ import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 import java.util.List;
+
 import org.junit.jupiter.api.DisplayName;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.springframework.context.ApplicationEventPublisher;
 
 import net.jqwik.api.Arbitraries;
+
 import com.cakk.api.common.annotation.TestWithDisplayName;
 import com.cakk.api.common.base.ServiceTest;
 import com.cakk.api.dto.response.shop.CakeShopDetailResponse;
-import com.cakk.common.enums.Days;
+import com.cakk.api.dto.response.shop.CakeShopSimpleResponse;
 import com.cakk.common.enums.ReturnCode;
 import com.cakk.common.exception.CakkException;
 import com.cakk.domain.dto.param.shop.CakeShopDetailParam;
-import com.cakk.domain.dto.param.shop.CakeShopSimpleResponse;
+import com.cakk.domain.dto.param.shop.CakeShopSimpleParam;
 import com.cakk.domain.repository.reader.CakeShopReader;
 import com.cakk.domain.repository.reader.UserReader;
 import com.cakk.domain.repository.writer.CakeShopWriter;
@@ -45,7 +47,7 @@ public class ShopServiceTest extends ServiceTest {
 	void searchSimpleById1() {
 		// given
 		Long cakeShopId = 1L;
-		CakeShopSimpleResponse response = getConstructorMonkey().giveMeBuilder(CakeShopSimpleResponse.class)
+		CakeShopSimpleParam response = getConstructorMonkey().giveMeBuilder(CakeShopSimpleParam.class)
 			.set("cakeShopId", Arbitraries.longs().greaterOrEqual(10))
 			.set("thumbnailUrl", Arbitraries.strings().alpha().ofMinLength(100).ofMaxLength(200))
 			.set("cakeShopName", Arbitraries.strings().alpha().ofMinLength(1).ofMaxLength(30))
@@ -58,7 +60,7 @@ public class ShopServiceTest extends ServiceTest {
 		CakeShopSimpleResponse result = shopService.searchSimpleById(cakeShopId);
 
 		// then
-		assertEquals(response, result);
+		assertEquals(CakeShopSimpleResponse.from(response), result);
 
 		verify(cakeShopReader, times(1)).searchSimpleById(cakeShopId);
 	}

--- a/cakk-api/src/test/java/com/cakk/api/service/shop/ShopServiceTest.java
+++ b/cakk-api/src/test/java/com/cakk/api/service/shop/ShopServiceTest.java
@@ -17,6 +17,7 @@ import com.cakk.api.common.annotation.TestWithDisplayName;
 import com.cakk.api.common.base.ServiceTest;
 import com.cakk.api.dto.response.shop.CakeShopDetailResponse;
 import com.cakk.api.dto.response.shop.CakeShopSimpleResponse;
+import com.cakk.api.mapper.ShopMapper;
 import com.cakk.common.enums.ReturnCode;
 import com.cakk.common.exception.CakkException;
 import com.cakk.domain.dto.param.shop.CakeShopDetailParam;
@@ -60,7 +61,7 @@ public class ShopServiceTest extends ServiceTest {
 		CakeShopSimpleResponse result = shopService.searchSimpleById(cakeShopId);
 
 		// then
-		assertEquals(CakeShopSimpleResponse.from(response), result);
+		assertEquals(ShopMapper.cakeShopSimpleResponseFromParam(response), result);
 
 		verify(cakeShopReader, times(1)).searchSimpleById(cakeShopId);
 	}
@@ -101,7 +102,7 @@ public class ShopServiceTest extends ServiceTest {
 		CakeShopDetailResponse result = shopService.searchDetailById(cakeShopId);
 
 		// then
-		assertEquals(CakeShopDetailResponse.from(param), result);
+		assertEquals(ShopMapper.cakeShopDetailResponseFromParam(param), result);
 
 		verify(cakeShopReader, times(1)).searchDetailById(cakeShopId);
 	}

--- a/cakk-api/src/test/resources/sql/insert-cake-shop.sql
+++ b/cakk-api/src/test/resources/sql/insert-cake-shop.sql
@@ -3,3 +3,24 @@ insert into cake_shop (shop_id, thumbnail_url, shop_name, shop_bio, shop_descrip
 values (1, 'thumbnail_url1', '케이크 맛집1', '케이크 맛집입니다.', '케이크 맛집입니다.', 37.123456, 127.123456, 0, false, now(), now()),
        (2, 'thumbnail_url2', '케이크 맛집2', '케이크 맛집입니다.', '케이크 맛집입니다.', 38.123456, 128.123456, 0, false, now(), now()),
        (3, 'thumbnail_url3', '케이크 맛집3', '케이크 맛집입니다.', '케이크 맛집입니다.', 39.123456, 129.123456, 0, false, now(), now());
+
+insert into cake_shop_operation (operation_id, shop_id, operation_day, start_time, end_time, created_at, updated_at)
+values (1, 1, 0, '10:00:00', '22:00:00', now(), now()),
+       (2, 1, 1, '10:00:00', '22:00:00', now(), now()),
+       (3, 1, 2, '10:00:00', '20:00:00', now(), now()),
+       (4, 1, 3, '10:00:00', '22:00:00', now(), now()),
+       (5, 1, 4, '10:00:00', '22:00:00', now(), now()),
+       (6, 2, 0, '8:00:00', '21:00:00', now(), now()),
+       (7, 2, 2, '8:00:00', '21:00:00', now(), now()),
+       (8, 2, 4, '8:00:00', '21:00:00', now(), now()),
+       (9, 3, 5, '7:00:00', '19:00:00', now(), now()),
+       (10, 3, 6, '7:00:00', '19:00:00', now(), now());
+
+insert into cake_shop_link (link_id, shop_id, link_kind, link_path, created_at, updated_at)
+values (1, 1, 'WEB', 'https://www.cake-shop1.com', now(), now()),
+       (2, 1, 'INSTAGRAM', 'https://www.instagram.com/cake-shop1', now(), now()),
+       (3, 1, 'KAKAOTALK', 'https://www.kakaotalk.com/cake-shop1', now(), now()),
+       (4, 2, 'WEB', 'https://www.cake-shop2.com', now(), now()),
+       (5, 2, 'INSTAGRAM', 'https://www.instagram.com/cake-shop2', now(), now()),
+       (6, 3, 'WEB', 'https://www.cake-shop3.com', now(), now()),
+       (7, 3, 'KAKAOTALK', 'https://www.kakaotalk.com/cake-shop3', now(), now());

--- a/cakk-api/src/test/resources/sql/insert-cake-shop.sql
+++ b/cakk-api/src/test/resources/sql/insert-cake-shop.sql
@@ -17,10 +17,10 @@ values (1, 1, 0, '10:00:00', '22:00:00', now(), now()),
        (10, 3, 6, '7:00:00', '19:00:00', now(), now());
 
 insert into cake_shop_link (link_id, shop_id, link_kind, link_path, created_at, updated_at)
-values (1, 1, 'WEB', 'https://www.cake-shop1.com', now(), now()),
-       (2, 1, 'INSTAGRAM', 'https://www.instagram.com/cake-shop1', now(), now()),
-       (3, 1, 'KAKAOTALK', 'https://www.kakaotalk.com/cake-shop1', now(), now()),
-       (4, 2, 'WEB', 'https://www.cake-shop2.com', now(), now()),
-       (5, 2, 'INSTAGRAM', 'https://www.instagram.com/cake-shop2', now(), now()),
-       (6, 3, 'WEB', 'https://www.cake-shop3.com', now(), now()),
-       (7, 3, 'KAKAOTALK', 'https://www.kakaotalk.com/cake-shop3', now(), now());
+values (1, 1, 'web', 'https://www.cake-shop1.com', now(), now()),
+       (2, 1, 'instagram', 'https://www.instagram.com/cake-shop1', now(), now()),
+       (3, 1, 'kakaotalk', 'https://www.kakaotalk.com/cake-shop1', now(), now()),
+       (4, 2, 'web', 'https://www.cake-shop2.com', now(), now()),
+       (5, 2, 'instagram', 'https://www.instagram.com/cake-shop2', now(), now()),
+       (6, 3, 'web', 'https://www.cake-shop3.com', now(), now()),
+       (7, 3, 'kakaotalk', 'https://www.kakaotalk.com/cake-shop3', now(), now());

--- a/cakk-common/src/main/java/com/cakk/common/enums/LinkKind.java
+++ b/cakk-common/src/main/java/com/cakk/common/enums/LinkKind.java
@@ -1,6 +1,13 @@
 package com.cakk.common.enums;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum LinkKind {
 
-	WEB, KAKAOTALK, INSTAGRAM
+	WEB("web"), KAKAOTALK("kakaotalk"), INSTAGRAM("instagram");
+
+	private final String value;
 }

--- a/cakk-domain/src/main/java/com/cakk/domain/converter/LinkKindConverter.java
+++ b/cakk-domain/src/main/java/com/cakk/domain/converter/LinkKindConverter.java
@@ -1,0 +1,33 @@
+package com.cakk.domain.converter;
+
+import java.util.stream.Stream;
+
+import jakarta.persistence.AttributeConverter;
+
+import com.cakk.common.enums.LinkKind;
+import com.cakk.common.enums.ReturnCode;
+import com.cakk.common.exception.CakkException;
+
+public class LinkKindConverter implements AttributeConverter<LinkKind, String> {
+
+	@Override
+	public String convertToDatabaseColumn(LinkKind linkKind) {
+		if (linkKind == null) {
+			return null;
+		}
+
+		return linkKind.getValue();
+	}
+
+	@Override
+	public LinkKind convertToEntityAttribute(String value) {
+		if (value == null) {
+			return null;
+		}
+
+		return Stream.of(LinkKind.values())
+			.filter(linkKind -> linkKind.getValue().equals(value))
+			.findFirst()
+			.orElseThrow(() -> new CakkException(ReturnCode.INTERNAL_SERVER_ERROR));
+	}
+}

--- a/cakk-domain/src/main/java/com/cakk/domain/dto/param/shop/CakeShopDetailParam.java
+++ b/cakk-domain/src/main/java/com/cakk/domain/dto/param/shop/CakeShopDetailParam.java
@@ -1,6 +1,6 @@
 package com.cakk.domain.dto.param.shop;
 
-import java.util.List;
+import java.util.Set;
 
 import com.cakk.common.enums.Days;
 
@@ -10,7 +10,7 @@ public record CakeShopDetailParam(
 	String thumbnailUrl,
 	String shopBio,
 	String shopDescription,
-	List<Days> operationDay,
-	List<CakeShopLinkParam> links
+	Set<Days> operationDays,
+	Set<CakeShopLinkParam> links
 ) {
 }

--- a/cakk-domain/src/main/java/com/cakk/domain/dto/param/shop/CakeShopSimpleParam.java
+++ b/cakk-domain/src/main/java/com/cakk/domain/dto/param/shop/CakeShopSimpleParam.java
@@ -1,6 +1,6 @@
 package com.cakk.domain.dto.param.shop;
 
-public record CakeShopSimpleResponse(
+public record CakeShopSimpleParam(
 	Long cakeShopId,
 	String thumbnailUrl,
 	String cakeShopName,

--- a/cakk-domain/src/main/java/com/cakk/domain/entity/shop/CakeShopLink.java
+++ b/cakk-domain/src/main/java/com/cakk/domain/entity/shop/CakeShopLink.java
@@ -2,6 +2,8 @@ package com.cakk.domain.entity.shop;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -29,10 +31,11 @@ public class CakeShopLink extends AuditEntity {
 	@Column(name = "link_id", nullable = false)
 	private Long id;
 
+	@Enumerated(value = EnumType.STRING)
 	@Column(name = "link_kind", nullable = false, length = 20)
 	private LinkKind linkKind;
 
-	@Column(name = "link_path", nullable = false, length = 20)
+	@Column(name = "link_path", nullable = false, length = 200)
 	private String linkPath;
 
 	@ManyToOne(fetch = FetchType.LAZY)

--- a/cakk-domain/src/main/java/com/cakk/domain/entity/shop/CakeShopLink.java
+++ b/cakk-domain/src/main/java/com/cakk/domain/entity/shop/CakeShopLink.java
@@ -1,9 +1,8 @@
 package com.cakk.domain.entity.shop;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -18,6 +17,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import com.cakk.common.enums.LinkKind;
+import com.cakk.domain.converter.LinkKindConverter;
 import com.cakk.domain.entity.audit.AuditEntity;
 
 @Getter
@@ -31,7 +31,7 @@ public class CakeShopLink extends AuditEntity {
 	@Column(name = "link_id", nullable = false)
 	private Long id;
 
-	@Enumerated(value = EnumType.STRING)
+	@Convert(converter = LinkKindConverter.class)
 	@Column(name = "link_kind", nullable = false, length = 20)
 	private LinkKind linkKind;
 

--- a/cakk-domain/src/main/java/com/cakk/domain/entity/shop/CakeShopOperation.java
+++ b/cakk-domain/src/main/java/com/cakk/domain/entity/shop/CakeShopOperation.java
@@ -21,7 +21,6 @@ import lombok.NoArgsConstructor;
 import com.cakk.common.enums.Days;
 import com.cakk.domain.converter.DayOfWeekConverter;
 import com.cakk.domain.entity.audit.AuditEntity;
-import com.cakk.domain.entity.shop.CakeShop;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/cakk-domain/src/main/java/com/cakk/domain/repository/jpa/CakeShopLinkJpaRepository.java
+++ b/cakk-domain/src/main/java/com/cakk/domain/repository/jpa/CakeShopLinkJpaRepository.java
@@ -1,0 +1,12 @@
+package com.cakk.domain.repository.jpa;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.cakk.domain.entity.shop.CakeShopLink;
+
+public interface CakeShopLinkJpaRepository extends JpaRepository<CakeShopLink, Long> {
+
+	List<CakeShopLink> findAllByCakeShopId(Long cakeShopId);
+}

--- a/cakk-domain/src/main/java/com/cakk/domain/repository/jpa/CakeShopOperationJpaRepository.java
+++ b/cakk-domain/src/main/java/com/cakk/domain/repository/jpa/CakeShopOperationJpaRepository.java
@@ -1,7 +1,12 @@
 package com.cakk.domain.repository.jpa;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.cakk.domain.entity.shop.CakeShopOperation;
 
-public interface CakeShopOperationJpaRepository extends JpaRepository<CakeShopOperation, Long> { }
+public interface CakeShopOperationJpaRepository extends JpaRepository<CakeShopOperation, Long> {
+
+	List<CakeShopOperation> findAllByCakeShopId(Long cakeShopId);
+}

--- a/cakk-domain/src/main/java/com/cakk/domain/repository/query/CakeShopQueryRepository.java
+++ b/cakk-domain/src/main/java/com/cakk/domain/repository/query/CakeShopQueryRepository.java
@@ -18,7 +18,7 @@ import lombok.RequiredArgsConstructor;
 import com.cakk.common.enums.Days;
 import com.cakk.domain.dto.param.shop.CakeShopDetailParam;
 import com.cakk.domain.dto.param.shop.CakeShopLinkParam;
-import com.cakk.domain.dto.param.shop.CakeShopSimpleResponse;
+import com.cakk.domain.dto.param.shop.CakeShopSimpleParam;
 
 @Repository
 @RequiredArgsConstructor
@@ -53,8 +53,8 @@ public class CakeShopQueryRepository {
 		return results.isEmpty() ? null : results.get(0);
 	}
 
-	public CakeShopSimpleResponse searchSimpleById(Long cakeShopId) {
-		return queryFactory.select(Projections.constructor(CakeShopSimpleResponse.class,
+	public CakeShopSimpleParam searchSimpleById(Long cakeShopId) {
+		return queryFactory.select(Projections.constructor(CakeShopSimpleParam.class,
 				cakeShop.id,
 				cakeShop.thumbnailUrl,
 				cakeShop.shopName,

--- a/cakk-domain/src/main/java/com/cakk/domain/repository/query/CakeShopQueryRepository.java
+++ b/cakk-domain/src/main/java/com/cakk/domain/repository/query/CakeShopQueryRepository.java
@@ -15,7 +15,6 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
 
-import com.cakk.common.enums.Days;
 import com.cakk.domain.dto.param.shop.CakeShopDetailParam;
 import com.cakk.domain.dto.param.shop.CakeShopLinkParam;
 import com.cakk.domain.dto.param.shop.CakeShopSimpleParam;
@@ -41,10 +40,8 @@ public class CakeShopQueryRepository {
 					cakeShop.thumbnailUrl,
 					cakeShop.shopBio,
 					cakeShop.shopDescription,
-					list(Projections.constructor(Days.class,
-						cakeShopOperation.operationDay)
-					),
-					list(Projections.constructor(CakeShopLinkParam.class,
+					set(cakeShopOperation.operationDay),
+					set(Projections.constructor(CakeShopLinkParam.class,
 						cakeShopLink.linkKind,
 						cakeShopLink.linkPath)
 					)

--- a/cakk-domain/src/main/java/com/cakk/domain/repository/reader/CakeShopLinkReader.java
+++ b/cakk-domain/src/main/java/com/cakk/domain/repository/reader/CakeShopLinkReader.java
@@ -1,0 +1,20 @@
+package com.cakk.domain.repository.reader;
+
+import java.util.List;
+
+import lombok.RequiredArgsConstructor;
+
+import com.cakk.domain.annotation.Reader;
+import com.cakk.domain.entity.shop.CakeShopLink;
+import com.cakk.domain.repository.jpa.CakeShopLinkJpaRepository;
+
+@Reader
+@RequiredArgsConstructor
+public class CakeShopLinkReader {
+
+	private final CakeShopLinkJpaRepository cakeShopLinkJpaRepository;
+
+	public List<CakeShopLink> findAllByCakeShopId(Long cakeShopId) {
+		return cakeShopLinkJpaRepository.findAllByCakeShopId(cakeShopId);
+	}
+}

--- a/cakk-domain/src/main/java/com/cakk/domain/repository/reader/CakeShopOperationReader.java
+++ b/cakk-domain/src/main/java/com/cakk/domain/repository/reader/CakeShopOperationReader.java
@@ -1,0 +1,20 @@
+package com.cakk.domain.repository.reader;
+
+import java.util.List;
+
+import lombok.RequiredArgsConstructor;
+
+import com.cakk.domain.annotation.Reader;
+import com.cakk.domain.entity.shop.CakeShopOperation;
+import com.cakk.domain.repository.jpa.CakeShopOperationJpaRepository;
+
+@Reader
+@RequiredArgsConstructor
+public class CakeShopOperationReader {
+
+	private final CakeShopOperationJpaRepository cakeShopOperationJpaRepository;
+
+	public List<CakeShopOperation> findAllByCakeShopId(Long cakeShopId) {
+		return cakeShopOperationJpaRepository.findAllByCakeShopId(cakeShopId);
+	}
+}

--- a/cakk-domain/src/main/java/com/cakk/domain/repository/reader/CakeShopReader.java
+++ b/cakk-domain/src/main/java/com/cakk/domain/repository/reader/CakeShopReader.java
@@ -8,7 +8,7 @@ import com.cakk.common.enums.ReturnCode;
 import com.cakk.common.exception.CakkException;
 import com.cakk.domain.annotation.Reader;
 import com.cakk.domain.dto.param.shop.CakeShopDetailParam;
-import com.cakk.domain.dto.param.shop.CakeShopSimpleResponse;
+import com.cakk.domain.dto.param.shop.CakeShopSimpleParam;
 import com.cakk.domain.entity.shop.CakeShop;
 import com.cakk.domain.entity.user.BusinessInformation;
 import com.cakk.domain.repository.jpa.BusinessInformationJpaRepository;
@@ -27,8 +27,8 @@ public class CakeShopReader {
 		return cakeShopJpaRepository.findById(cakeShopId).orElseThrow(() -> new CakkException(ReturnCode.NOT_EXIST_CAKE_SHOP));
 	}
 
-	public CakeShopSimpleResponse searchSimpleById(final Long cakeShopId) {
-		final CakeShopSimpleResponse response = cakeShopQueryRepository.searchSimpleById(cakeShopId);
+	public CakeShopSimpleParam searchSimpleById(final Long cakeShopId) {
+		final CakeShopSimpleParam response = cakeShopQueryRepository.searchSimpleById(cakeShopId);
 
 		if (isNull(response)) {
 			throw new CakkException(ReturnCode.NOT_EXIST_CAKE_SHOP);


### PR DESCRIPTION
> ### Issue Number

#24

> ### Description

케이크 샵 상세조회 API를 구현하고 통합테스트를 작성했습니다. 통합 테스트를 진행하던 도중 쿼리에 오류를 발견하여 수정하였습니다. 쿼리는 다음과 같습니다.

(수정 사항이 몇개 있어서 pr이 커져버렸습니다..)

```sql
select cs1_0.shop_id,
       cs1_0.shop_name,
       cs1_0.thumbnail_url,
       cs1_0.shop_bio,
       cs1_0.shop_description,
       cso1_0.operation_day,
       csl1_0.link_kind,
       csl1_0.link_path 
from cake_shop cs1_0 
join cake_shop_operation cso1_0 
on cs1_0.shop_id = cso1_0.shop_id 
join cake_shop_link csl1_0 
on cs1_0.shop_id = csl1_0.shop_id 
where cs1_0.shop_id = ?
```
> ### Core Code

```java
. . .
	final ApiResponse response = objectMapper.convertValue(responseEntity.getBody(), ApiResponse.class);
	final CakeShopDetailResponse data = objectMapper.convertValue(response.getData(), CakeShopDetailResponse.class);

	assertEquals(HttpStatusCode.valueOf(200), responseEntity.getStatusCode());
	assertEquals(ReturnCode.SUCCESS.getCode(), response.getReturnCode());
	assertEquals(ReturnCode.SUCCESS.getMessage(), response.getReturnMessage());

	final CakeShop cakeShop = cakeShopReader.findById(cakeShopId);
	assertEquals(cakeShop.getId(), data.cakeShopId());
	assertEquals(cakeShop.getThumbnailUrl(), data.thumbnailUrl());
	assertEquals(cakeShop.getShopName(), data.cakeShopName());
	assertEquals(cakeShop.getShopBio(), data.cakeShopBio());
	assertEquals(cakeShop.getShopDescription(), data.cakeShopDescription());

	final Set<Days> cakeShopOperations = cakeShopOperationReader.findAllByCakeShopId(cakeShopId).stream()
		.map(CakeShopOperation::getOperationDay)
		.collect(Collectors.toSet());
	assertEquals(cakeShopOperations, data.operationDays());

	final Set<CakeShopLinkParam> cakeShopLinks = cakeShopLinkReader.findAllByCakeShopId(cakeShopId).stream()
		.map((it) -> new CakeShopLinkParam(it.getLinkKind(), it.getLinkPath()))
		.collect(Collectors.toSet());
	assertEquals(cakeShopLinks, data.links());
. . .
```

> ### etc
