### PR TITLE
Feature: 케이크 샵에 속한 케이크 다건 조회 구현

### DIFF
--- a/cakk-api/src/main/java/com/cakk/api/controller/cake/CakeController.java
+++ b/cakk-api/src/main/java/com/cakk/api/controller/cake/CakeController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 import lombok.RequiredArgsConstructor;
 
 import com.cakk.api.dto.request.cake.CakeSearchByCategoryRequest;
+import com.cakk.api.dto.request.cake.CakeSearchByShopRequest;
 import com.cakk.api.dto.response.cake.CakeImageListResponse;
 import com.cakk.api.service.cake.CakeService;
 import com.cakk.common.response.ApiResponse;
@@ -26,6 +27,15 @@ public class CakeController {
 		@Valid @ModelAttribute CakeSearchByCategoryRequest request
 	) {
 		final CakeImageListResponse response = cakeService.findCakeImagesByCursorAndCategory(request);
+
+		return ApiResponse.success(response);
+	}
+
+	@GetMapping("/search/shops")
+	public ApiResponse<CakeImageListResponse> listByShop(
+		@Valid @ModelAttribute CakeSearchByShopRequest request
+	) {
+		final CakeImageListResponse response = cakeService.findCakeImagesByCursorAndCakeShopId(request);
 
 		return ApiResponse.success(response);
 	}

--- a/cakk-api/src/main/java/com/cakk/api/dto/request/cake/CakeSearchByShopRequest.java
+++ b/cakk-api/src/main/java/com/cakk/api/dto/request/cake/CakeSearchByShopRequest.java
@@ -1,0 +1,12 @@
+package com.cakk.api.dto.request.cake;
+
+import jakarta.validation.constraints.NotNull;
+
+public record CakeSearchByShopRequest(
+	Long cakeId,
+	@NotNull
+	Long cakeShopId,
+	@NotNull
+	Integer pageSize
+) {
+}

--- a/cakk-api/src/main/java/com/cakk/api/mapper/CakeMapper.java
+++ b/cakk-api/src/main/java/com/cakk/api/mapper/CakeMapper.java
@@ -1,0 +1,23 @@
+package com.cakk.api.mapper;
+
+import java.util.List;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import com.cakk.api.dto.response.cake.CakeImageListResponse;
+import com.cakk.domain.dto.param.cake.CakeImageResponseParam;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CakeMapper {
+
+	public static CakeImageListResponse supplyCakeImageListResponse(List<CakeImageResponseParam> cakeImages) {
+		int size = cakeImages.size();
+
+		return CakeImageListResponse.builder()
+			.cakeImages(cakeImages)
+			.lastCakeId(cakeImages.isEmpty() ? null : cakeImages.get(size - 1).cakeId())
+			.size(cakeImages.size())
+			.build();
+	}
+}

--- a/cakk-api/src/main/java/com/cakk/api/service/cake/CakeService.java
+++ b/cakk-api/src/main/java/com/cakk/api/service/cake/CakeService.java
@@ -1,11 +1,16 @@
 package com.cakk.api.service.cake;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
 
 import com.cakk.api.dto.request.cake.CakeSearchByCategoryRequest;
+import com.cakk.api.dto.request.cake.CakeSearchByShopRequest;
 import com.cakk.api.dto.response.cake.CakeImageListResponse;
+import com.cakk.api.mapper.CakeMapper;
+import com.cakk.domain.dto.param.cake.CakeImageResponseParam;
 import com.cakk.domain.repository.reader.CakeReader;
 
 @Service
@@ -15,6 +20,16 @@ public class CakeService {
 	private final CakeReader cakeReader;
 
 	public CakeImageListResponse findCakeImagesByCursorAndCategory(final CakeSearchByCategoryRequest dto) {
-		return CakeImageListResponse.from(cakeReader.searchCakeImagesByCursorAndCategory(dto.cakeId(), dto.category(), dto.pageSize()));
+		final List<CakeImageResponseParam> cakeImages
+			= cakeReader.searchCakeImagesByCursorAndCategory(dto.cakeId(), dto.category(), dto.pageSize());
+
+		return CakeMapper.supplyCakeImageListResponse(cakeImages);
+	}
+
+	public CakeImageListResponse findCakeImagesByCursorAndCakeShopId(final CakeSearchByShopRequest dto) {
+		final List<CakeImageResponseParam> cakeImages
+			= cakeReader.searchCakeImagesByCursorAndCakeShopId(dto.cakeId(), dto.cakeShopId(), dto.pageSize());
+
+		return CakeMapper.supplyCakeImageListResponse(cakeImages);
 	}
 }

--- a/cakk-api/src/test/java/com/cakk/api/integration/cake/CakeIntegrationTest.java
+++ b/cakk-api/src/test/java/com/cakk/api/integration/cake/CakeIntegrationTest.java
@@ -122,4 +122,90 @@ class CakeIntegrationTest extends IntegrationTest {
 		assertNull(data.lastCakeId());
 		assertEquals(0, data.size());
 	}
+
+	@TestWithDisplayName("케이크 샵으로 첫 페이지 케이크 이미지 조회에 성공한다")
+	void searchByShopId1() {
+		// given
+		final String url = "%s%d%s/search/shops".formatted(BASE_URL, port, API_URL);
+		final UriComponents uriComponents = UriComponentsBuilder
+			.fromUriString(url)
+			.queryParam("cakeShopId", 1L)
+			.queryParam("pageSize", 4)
+			.build();
+
+		// when
+		final ResponseEntity<ApiResponse> responseEntity = restTemplate.getForEntity(uriComponents.toUriString(), ApiResponse.class);
+
+		// then
+		final ApiResponse response = objectMapper.convertValue(responseEntity.getBody(), ApiResponse.class);
+		final CakeImageListResponse data = objectMapper.convertValue(response.getData(), CakeImageListResponse.class);
+
+		assertEquals(HttpStatusCode.valueOf(200), responseEntity.getStatusCode());
+		assertEquals(ReturnCode.SUCCESS.getCode(), response.getReturnCode());
+		assertEquals(ReturnCode.SUCCESS.getMessage(), response.getReturnMessage());
+
+		Long lastCakeId = data.cakeImages().stream().map(CakeImageResponseParam::cakeId).min(Long::compareTo).orElse(null);
+		assertEquals(lastCakeId, data.lastCakeId());
+		assertEquals(4, data.size());
+		data.cakeImages().forEach(cakeImage -> {
+			assertEquals(Long.valueOf(1L), cakeImage.cakeShopId());
+		});
+	}
+
+	@TestWithDisplayName("케이크 샵으로 첫 페이지가 아닌 케이크 이미지 조회에 성공한다")
+	void searchByShopId2() {
+		// given
+		final String url = "%s%d%s/search/shops".formatted(BASE_URL, port, API_URL);
+		final UriComponents uriComponents = UriComponentsBuilder
+			.fromUriString(url)
+			.queryParam("cakeId", 5)
+			.queryParam("cakeShopId", 1L)
+			.queryParam("pageSize", 4)
+			.build();
+
+		// when
+		final ResponseEntity<ApiResponse> responseEntity = restTemplate.getForEntity(uriComponents.toUriString(), ApiResponse.class);
+
+		// then
+		final ApiResponse response = objectMapper.convertValue(responseEntity.getBody(), ApiResponse.class);
+		final CakeImageListResponse data = objectMapper.convertValue(response.getData(), CakeImageListResponse.class);
+
+		assertEquals(HttpStatusCode.valueOf(200), responseEntity.getStatusCode());
+		assertEquals(ReturnCode.SUCCESS.getCode(), response.getReturnCode());
+		assertEquals(ReturnCode.SUCCESS.getMessage(), response.getReturnMessage());
+
+		Long lastCakeId = data.cakeImages().stream().map(CakeImageResponseParam::cakeId).min(Long::compareTo).orElse(null);
+		assertEquals(lastCakeId, data.lastCakeId());
+		assertEquals(3, data.size());
+		data.cakeImages().forEach(cakeImage ->
+			assertEquals(Long.valueOf(1L), cakeImage.cakeShopId())
+		);
+	}
+
+	@TestWithDisplayName("케이크 샵으로 케이크 이미지 조회 시 데이터가 없으면 빈 배열을 반환한다")
+	void searchByShopId3() {
+		// given
+		final String url = "%s%d%s/search/shops".formatted(BASE_URL, port, API_URL);
+		final UriComponents uriComponents = UriComponentsBuilder
+			.fromUriString(url)
+			.queryParam("cakeId", 1)
+			.queryParam("cakeShopId", 1L)
+			.queryParam("pageSize", 4)
+			.build();
+
+		// when
+		final ResponseEntity<ApiResponse> responseEntity = restTemplate.getForEntity(uriComponents.toUriString(), ApiResponse.class);
+
+		// then
+		final ApiResponse response = objectMapper.convertValue(responseEntity.getBody(), ApiResponse.class);
+		final CakeImageListResponse data = objectMapper.convertValue(response.getData(), CakeImageListResponse.class);
+
+		assertEquals(HttpStatusCode.valueOf(200), responseEntity.getStatusCode());
+		assertEquals(ReturnCode.SUCCESS.getCode(), response.getReturnCode());
+		assertEquals(ReturnCode.SUCCESS.getMessage(), response.getReturnMessage());
+
+		assertEquals(0, data.cakeImages().size());
+		assertNull(data.lastCakeId());
+		assertEquals(0, data.size());
+	}
 }

--- a/cakk-api/src/test/resources/sql/insert-cake.sql
+++ b/cakk-api/src/test/resources/sql/insert-cake.sql
@@ -1,16 +1,17 @@
 insert into cake_shop (shop_id, thumbnail_url, shop_name, shop_bio, shop_description, latitude, longitude, like_count, linked_flag,
                        created_at, updated_at)
-values (1, 'thumbnail_url', '케이크 맛집', '케이크 맛집입니다.', '케이크 맛집입니다.', 37.123456, 127.123456, 0, false, now(), now());
+values (1, 'thumbnail_url', '케이크 맛집', '케이크 맛집입니다.', '케이크 맛집입니다.', 37.123456, 127.123456, 0, false, now(), now()),
+       (2, 'thumbnail_url2', '케이크 맛집2', '케이크 맛집입니다.', '케이크 맛집입니다.', 38.123456, 128.123456, 0, false, now(), now());
 
 insert into cake (cake_id, shop_id, cake_image_url, like_count, created_at, updated_at)
 values (1, 1, 'cake_image_url1', 0, now(), now()),
        (2, 1, 'cake_image_url2', 0, now(), now()),
-       (3, 1, 'cake_image_url3', 0, now(), now()),
+       (3, 2, 'cake_image_url3', 0, now(), now()),
        (4, 1, 'cake_image_url4', 0, now(), now()),
        (5, 1, 'cake_image_url5', 0, now(), now()),
        (6, 1, 'cake_image_url6', 0, now(), now()),
-       (7, 1, 'cake_image_url7', 0, now(), now()),
-       (8, 1, 'cake_image_url8', 0, now(), now()),
+       (7, 2, 'cake_image_url7', 0, now(), now()),
+       (8, 2, 'cake_image_url8', 0, now(), now()),
        (9, 1, 'cake_image_url9', 0, now(), now()),
        (10, 1, 'cake_image_url10', 0, now(), now());
 

--- a/cakk-domain/src/main/java/com/cakk/domain/repository/query/CakeQueryRepository.java
+++ b/cakk-domain/src/main/java/com/cakk/domain/repository/query/CakeQueryRepository.java
@@ -44,12 +44,35 @@ public class CakeQueryRepository {
 			.fetch();
 	}
 
+	public List<CakeImageResponseParam> searchCakeImagesByCursorAndCakeShopId(Long cakeId, Long cakeShopId, int pageSize) {
+		return queryFactory
+			.select(Projections.constructor(CakeImageResponseParam.class,
+				cakeShop.id,
+				cake.id,
+				cake.cakeImageUrl))
+			.from(cake)
+			.innerJoin(cakeShop)
+			.on(cake.cakeShop.eq(cakeShop))
+			.innerJoin(cakeCategory)
+			.on(cakeCategory.cake.eq(cake))
+			.where(
+				ltCakeId(cakeId),
+				eqCakeShopId(cakeShopId))
+			.limit(pageSize)
+			.orderBy(cakeIdDesc())
+			.fetch();
+	}
+
 	private BooleanExpression ltCakeId(Long cakeId) {
 		if (isNull(cakeId)) {
 			return null;
 		}
 
 		return cake.id.lt(cakeId);
+	}
+
+	private BooleanExpression eqCakeShopId(Long cakeShopId) {
+		return cakeShop.id.eq(cakeShopId);
 	}
 
 	private BooleanExpression eqCategory(CakeDesignCategory category) {

--- a/cakk-domain/src/main/java/com/cakk/domain/repository/reader/CakeReader.java
+++ b/cakk-domain/src/main/java/com/cakk/domain/repository/reader/CakeReader.java
@@ -27,4 +27,8 @@ public class CakeReader {
 	public List<CakeImageResponseParam> searchCakeImagesByCursorAndCategory(Long cakeId, CakeDesignCategory category, int pageSize) {
 		return cakeQueryRepository.searchCakeImagesByCursorAndCategory(cakeId, category, pageSize);
 	}
+
+	public List<CakeImageResponseParam> searchCakeImagesByCursorAndCakeShopId(Long cakeId, Long cakeShopId, int pageSize) {
+		return cakeQueryRepository.searchCakeImagesByCursorAndCakeShopId(cakeId, cakeShopId, pageSize);
+	}
 }


### PR DESCRIPTION
> ### Issue Number

#40

> ### Description

이전에 구현했던 `카테고리 별 케이크 다건조회`와 비슷하여 비즈니스와 api 구현을 한번에 구현하여 PR 올렸습니다. Query는 다음과 같습니다.

```sql
select cs1_0.shop_id,
           c1_0.cake_id,
           c1_0.cake_image_url 
from cake c1_0 
join cake_shop cs1_0 
on c1_0.shop_id = cs1_0.shop_id 
join cake_category cc1_0 
on cc1_0.cake_id = c1_0.cake_id 
where cs1_0.shop_id = ? 
order by c1_0.cake_id desc 
limit ?
```

> ### Core Code

```java
. . .
	public CakeImageListResponse findCakeImagesByCursorAndCakeShopId(final CakeSearchByShopRequest dto) {
		final List<CakeImageResponseParam> cakeImages
			= cakeReader.searchCakeImagesByCursorAndCakeShopId(dto.cakeId(), dto.cakeShopId(), dto.pageSize());

		return CakeMapper.supplyCakeImageListResponse(cakeImages);
	}
. . .
```

> ### etc
