### PR TITLE
Test: Shop 도메인 유닛 테스트 및 통합 테스트 추가

### DIFF
--- a/cakk-api/src/main/java/com/cakk/api/annotation/OperationDays.java
+++ b/cakk-api/src/main/java/com/cakk/api/annotation/OperationDays.java
@@ -5,9 +5,9 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import com.cakk.api.annotation.validator.OperationValidator;
-
 import jakarta.validation.Constraint;
+
+import com.cakk.api.annotation.validator.OperationValidator;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)

--- a/cakk-api/src/main/java/com/cakk/api/annotation/OperationDays.java
+++ b/cakk-api/src/main/java/com/cakk/api/annotation/OperationDays.java
@@ -1,0 +1,16 @@
+package com.cakk.api.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import com.cakk.api.annotation.validator.OperationValidator;
+
+import jakarta.validation.Constraint;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+@Constraint(validatedBy = OperationValidator.class)
+public @interface OperationDays {
+}

--- a/cakk-api/src/main/java/com/cakk/api/annotation/validator/OperationValidator.java
+++ b/cakk-api/src/main/java/com/cakk/api/annotation/validator/OperationValidator.java
@@ -17,5 +17,5 @@ public class OperationValidator implements ConstraintValidator<OperationDays, Op
 		}
 		return true;
 	}
-
 }
+

--- a/cakk-api/src/main/java/com/cakk/api/annotation/validator/OperationValidator.java
+++ b/cakk-api/src/main/java/com/cakk/api/annotation/validator/OperationValidator.java
@@ -1,10 +1,10 @@
 package com.cakk.api.annotation.validator;
 
-import com.cakk.api.annotation.OperationDays;
-import com.cakk.api.dto.request.shop.OperationDay;
-
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
+
+import com.cakk.api.annotation.OperationDays;
+import com.cakk.api.dto.request.shop.OperationDay;
 
 public class OperationValidator implements ConstraintValidator<OperationDays, OperationDay> {
 	@Override

--- a/cakk-api/src/main/java/com/cakk/api/annotation/validator/OperationValidator.java
+++ b/cakk-api/src/main/java/com/cakk/api/annotation/validator/OperationValidator.java
@@ -1,0 +1,19 @@
+package com.cakk.api.annotation.validator;
+
+import com.cakk.api.annotation.OperationDays;
+import com.cakk.api.dto.request.shop.OperationDay;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class OperationValidator implements ConstraintValidator<OperationDays, OperationDay> {
+	@Override
+	public boolean isValid(OperationDay value, ConstraintValidatorContext context) {
+		if (value.days().size() != value.startTimes().size()) {
+			return false;
+		} else if (value.days().size() != value.endTimes().size()) {
+			return false;
+		}
+		return true;
+	}
+}

--- a/cakk-api/src/main/java/com/cakk/api/annotation/validator/OperationValidator.java
+++ b/cakk-api/src/main/java/com/cakk/api/annotation/validator/OperationValidator.java
@@ -4,11 +4,12 @@ import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 
 import com.cakk.api.annotation.OperationDays;
-import com.cakk.api.dto.request.shop.OperationDay;
+import com.cakk.api.dto.request.shop.OperationDayRequest;
 
-public class OperationValidator implements ConstraintValidator<OperationDays, OperationDay> {
+public class OperationValidator implements ConstraintValidator<OperationDays, OperationDayRequest> {
+
 	@Override
-	public boolean isValid(OperationDay value, ConstraintValidatorContext context) {
+	public boolean isValid(OperationDayRequest value, ConstraintValidatorContext context) {
 		if (value.days().size() != value.startTimes().size()) {
 			return false;
 		} else if (value.days().size() != value.endTimes().size()) {
@@ -16,4 +17,5 @@ public class OperationValidator implements ConstraintValidator<OperationDays, Op
 		}
 		return true;
 	}
+
 }

--- a/cakk-api/src/main/java/com/cakk/api/dto/request/shop/CreateShopRequest.java
+++ b/cakk-api/src/main/java/com/cakk/api/dto/request/shop/CreateShopRequest.java
@@ -1,27 +1,16 @@
 package com.cakk.api.dto.request.shop;
 
-import java.time.LocalTime;
-import java.util.List;
-
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
 
-import com.cakk.common.enums.Days;
+import com.cakk.api.annotation.OperationDays;
 
 public record CreateShopRequest(
 
 	@NotBlank
 	String businessNumber,
-	@NotNull
-	@Size(min = 1, max = 7)
-	List<Days> operationsDays,
-	@NotNull
-	@Size(min = 1, max = 7)
-	List<LocalTime> startTimes,
-	@NotNull
-	@Size(min = 1, max = 7)
-	List<LocalTime> endTimes,
+	@OperationDays
+	OperationDay operationDays,
 	@NotBlank
 	String shopName,
 	String shopBio,

--- a/cakk-api/src/main/java/com/cakk/api/dto/request/shop/CreateShopRequest.java
+++ b/cakk-api/src/main/java/com/cakk/api/dto/request/shop/CreateShopRequest.java
@@ -10,7 +10,7 @@ public record CreateShopRequest(
 	@NotBlank
 	String businessNumber,
 	@OperationDays
-	OperationDay operationDays,
+	OperationDayRequest operationDayRequest,
 	@NotBlank
 	String shopName,
 	String shopBio,

--- a/cakk-api/src/main/java/com/cakk/api/dto/request/shop/OperationDay.java
+++ b/cakk-api/src/main/java/com/cakk/api/dto/request/shop/OperationDay.java
@@ -1,0 +1,19 @@
+package com.cakk.api.dto.request.shop;
+
+import java.time.LocalTime;
+import java.util.List;
+
+import com.cakk.common.enums.Days;
+
+import jakarta.validation.constraints.NotNull;
+
+public record OperationDay(
+
+	@NotNull
+	List<Days> days,
+	@NotNull
+	List<LocalTime> startTimes,
+	@NotNull
+	List<LocalTime> endTimes
+) {
+}

--- a/cakk-api/src/main/java/com/cakk/api/dto/request/shop/OperationDay.java
+++ b/cakk-api/src/main/java/com/cakk/api/dto/request/shop/OperationDay.java
@@ -3,9 +3,9 @@ package com.cakk.api.dto.request.shop;
 import java.time.LocalTime;
 import java.util.List;
 
-import com.cakk.common.enums.Days;
-
 import jakarta.validation.constraints.NotNull;
+
+import com.cakk.common.enums.Days;
 
 public record OperationDay(
 

--- a/cakk-api/src/main/java/com/cakk/api/dto/request/shop/OperationDayRequest.java
+++ b/cakk-api/src/main/java/com/cakk/api/dto/request/shop/OperationDayRequest.java
@@ -7,7 +7,7 @@ import jakarta.validation.constraints.NotNull;
 
 import com.cakk.common.enums.Days;
 
-public record OperationDay(
+public record OperationDayRequest(
 
 	@NotNull
 	List<Days> days,

--- a/cakk-api/src/main/java/com/cakk/api/mapper/ShopMapper.java
+++ b/cakk-api/src/main/java/com/cakk/api/mapper/ShopMapper.java
@@ -39,6 +39,7 @@ public class ShopMapper {
 
 	public static BusinessInformation supplyBusinessInformationBy() {
 		return BusinessInformation.builder()
+			.cakeShop(CakeShop.builder().build())
 			.build();
 	}
 

--- a/cakk-api/src/main/java/com/cakk/api/provider/jwt/JwtProvider.java
+++ b/cakk-api/src/main/java/com/cakk/api/provider/jwt/JwtProvider.java
@@ -12,7 +12,6 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 
-import com.cakk.common.enums.ReturnCode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.jsonwebtoken.Claims;

--- a/cakk-api/src/main/java/com/cakk/api/service/shop/ShopService.java
+++ b/cakk-api/src/main/java/com/cakk/api/service/shop/ShopService.java
@@ -9,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 
 import com.cakk.api.dto.request.shop.CreateShopRequest;
+import com.cakk.api.dto.request.shop.OperationDayRequest;
 import com.cakk.api.dto.request.shop.PromotionRequest;
 import com.cakk.api.dto.response.shop.CakeShopDetailResponse;
 import com.cakk.api.dto.response.shop.CakeShopSimpleResponse;
@@ -37,14 +38,15 @@ public class ShopService {
 
 	@Transactional
 	public void createCakeShopByCertification(CreateShopRequest request) {
+		final OperationDayRequest operationDayRequest = request.operationDayRequest();
 		CakeShop cakeShop = ShopMapper.supplyCakeShopBy(request);
 		BusinessInformation businessInformation = ShopMapper.supplyBusinessInformationBy(request, cakeShop);
 		List<CakeShopOperation> cakeShopOperations = ShopMapper
 			.supplyCakeShopOperationsBy(
 				cakeShop,
-				request.operationDays().days(),
-				request.operationDays().startTimes(),
-				request.operationDays().endTimes()
+				operationDayRequest.days(),
+				operationDayRequest.startTimes(),
+				operationDayRequest.endTimes()
 			);
 
 		cakeShopWriter.createCakeShop(cakeShop, cakeShopOperations, businessInformation);

--- a/cakk-api/src/main/java/com/cakk/api/service/shop/ShopService.java
+++ b/cakk-api/src/main/java/com/cakk/api/service/shop/ShopService.java
@@ -40,7 +40,12 @@ public class ShopService {
 		CakeShop cakeShop = ShopMapper.supplyCakeShopBy(request);
 		BusinessInformation businessInformation = ShopMapper.supplyBusinessInformationBy(request, cakeShop);
 		List<CakeShopOperation> cakeShopOperations = ShopMapper
-			.supplyCakeShopOperationsBy(cakeShop, request.operationsDays(), request.startTimes(), request.endTimes());
+			.supplyCakeShopOperationsBy(
+				cakeShop,
+				request.operationDays().days(),
+				request.operationDays().startTimes(),
+				request.operationDays().endTimes()
+			);
 
 		cakeShopWriter.createCakeShop(cakeShop, cakeShopOperations, businessInformation);
 	}

--- a/cakk-api/src/main/resources/application.yml
+++ b/cakk-api/src/main/resources/application.yml
@@ -16,10 +16,12 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect
         format_sql: true
-        show_sql: true
+        show_sql: false
   flyway:
     enabled: true
     baseline-on-migrate: true
+  jackson:
+    date-format: yyyy-MM-dd HH:mm:ss
 
 decorator:
   datasource:

--- a/cakk-api/src/test/java/com/cakk/api/integration/shop/ShopIntegrationTest.java
+++ b/cakk-api/src/test/java/com/cakk/api/integration/shop/ShopIntegrationTest.java
@@ -178,10 +178,10 @@ public class ShopIntegrationTest extends IntegrationTest {
 		HttpHeaders httpHeaders = new HttpHeaders();
 		httpHeaders.add(HttpHeaders.AUTHORIZATION, "Bearer " + jsonWebToken.accessToken());
 		CertificationRequest request = getConstructorMonkey().giveMeBuilder(CertificationRequest.class)
-			.set("businessRegistrationImageUrl", Arbitraries.strings().withCharRange('a', 'z').ofMaxLength(40))
-			.set("idCardImageUrl", Arbitraries.strings().withCharRange('a', 'z').ofMaxLength(40))
+			.set("businessRegistrationImageUrl", Arbitraries.strings().withCharRange('a', 'z').ofMaxLength(40).ofMinLength(1))
+			.set("idCardImageUrl", Arbitraries.strings().withCharRange('a', 'z').ofMaxLength(40).ofMinLength(1))
 			.setNull("cakeShopId")
-			.set("emergencyContact", Arbitraries.strings().withCharRange('a', 'z').ofMaxLength(11))
+			.set("emergencyContact", Arbitraries.strings().withCharRange('a', 'z').ofMaxLength(11).ofMinLength(1))
 			.set("message", Arbitraries.strings().withCharRange('a', 'z').ofMaxLength(20)).sample();
 		HttpEntity<CertificationRequest> entity = new HttpEntity<>(request, httpHeaders);
 
@@ -206,10 +206,10 @@ public class ShopIntegrationTest extends IntegrationTest {
 		HttpHeaders httpHeaders = new HttpHeaders();
 		httpHeaders.add(HttpHeaders.AUTHORIZATION, "Bearer " + jsonWebToken.accessToken());
 		CertificationRequest request = getConstructorMonkey().giveMeBuilder(CertificationRequest.class)
-			.set("businessRegistrationImageUrl", Arbitraries.strings().withCharRange('a', 'z').ofMaxLength(40))
-			.set("idCardImageUrl", Arbitraries.strings().withCharRange('a', 'z').ofMaxLength(40))
+			.set("businessRegistrationImageUrl", Arbitraries.strings().withCharRange('a', 'z').ofMaxLength(40).ofMinLength(1))
+			.set("idCardImageUrl", Arbitraries.strings().withCharRange('a', 'z').ofMaxLength(40).ofMinLength(1))
 			.set("cakeShopId", Arbitraries.longs().greaterOrEqual(1).lessOrEqual(3))
-			.set("emergencyContact", Arbitraries.strings().withCharRange('a', 'z').ofMaxLength(11))
+			.set("emergencyContact", Arbitraries.strings().withCharRange('a', 'z').ofMaxLength(11).ofMinLength(1))
 			.set("message", Arbitraries.strings().withCharRange('a', 'z').ofMaxLength(20)).sample();
 		HttpEntity<CertificationRequest> entity = new HttpEntity<>(request, httpHeaders);
 

--- a/cakk-api/src/test/java/com/cakk/api/integration/shop/ShopIntegrationTest.java
+++ b/cakk-api/src/test/java/com/cakk/api/integration/shop/ShopIntegrationTest.java
@@ -6,6 +6,8 @@ import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.*;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.jdbc.Sql;
@@ -13,21 +15,29 @@ import org.springframework.test.context.jdbc.SqlGroup;
 import org.springframework.web.util.UriComponents;
 import org.springframework.web.util.UriComponentsBuilder;
 
+import net.jqwik.api.Arbitraries;
+
 import com.cakk.api.common.annotation.TestWithDisplayName;
 import com.cakk.api.common.base.IntegrationTest;
+import com.cakk.api.dto.request.user.CertificationRequest;
 import com.cakk.api.dto.response.shop.CakeShopDetailResponse;
 import com.cakk.api.dto.response.shop.CakeShopSimpleResponse;
+import com.cakk.api.provider.jwt.JwtProvider;
+import com.cakk.api.vo.JsonWebToken;
 import com.cakk.common.enums.Days;
 import com.cakk.common.enums.ReturnCode;
 import com.cakk.common.response.ApiResponse;
 import com.cakk.domain.dto.param.shop.CakeShopLinkParam;
 import com.cakk.domain.entity.shop.CakeShop;
 import com.cakk.domain.entity.shop.CakeShopOperation;
+import com.cakk.domain.entity.user.User;
 import com.cakk.domain.repository.reader.CakeShopLinkReader;
 import com.cakk.domain.repository.reader.CakeShopOperationReader;
 import com.cakk.domain.repository.reader.CakeShopReader;
+import com.cakk.domain.repository.reader.UserReader;
 
 @SqlGroup({
+	@Sql(scripts = "/sql/insert-test-user.sql", executionPhase = BEFORE_TEST_METHOD),
 	@Sql(scripts = "/sql/insert-cake-shop.sql", executionPhase = BEFORE_TEST_METHOD),
 	@Sql(scripts = "/sql/delete-all.sql", executionPhase = AFTER_TEST_METHOD)
 })
@@ -43,6 +53,12 @@ public class ShopIntegrationTest extends IntegrationTest {
 
 	@Autowired
 	private CakeShopLinkReader cakeShopLinkReader;
+
+	@Autowired
+	private JwtProvider jwtProvider;
+
+	@Autowired
+	private UserReader userReader;
 
 	@TestWithDisplayName("케이크 샵을 간단 조회에 성공한다.")
 	void simple1() {
@@ -149,4 +165,59 @@ public class ShopIntegrationTest extends IntegrationTest {
 		assertEquals(ReturnCode.NOT_EXIST_CAKE_SHOP.getMessage(), response.getReturnMessage());
 	}
 
+	@TestWithDisplayName("로그인한 사용자는 자신의 케이크샵이 존재하지 않은 상태에서 사장님 인증을 요청한다")
+	void request1() {
+		final String url = "%s%d%s".formatted(BASE_URL, port, API_URL);
+		final UriComponents uriComponents = UriComponentsBuilder
+			.fromUriString(url)
+			.path("/certification")
+			.build();
+		User user = userReader.findByUserId(1L);
+
+		JsonWebToken jsonWebToken = jwtProvider.generateToken(user);
+		HttpHeaders httpHeaders = new HttpHeaders();
+		httpHeaders.add(HttpHeaders.AUTHORIZATION, "Bearer " + jsonWebToken.accessToken());
+		CertificationRequest request = getConstructorMonkey().giveMeBuilder(CertificationRequest.class)
+			.set("businessRegistrationImageUrl", Arbitraries.strings().withCharRange('a', 'z').ofMaxLength(40))
+			.set("idCardImageUrl", Arbitraries.strings().withCharRange('a', 'z').ofMaxLength(40))
+			.setNull("cakeShopId")
+			.set("emergencyContact", Arbitraries.strings().withCharRange('a', 'z').ofMaxLength(11))
+			.set("message", Arbitraries.strings().withCharRange('a', 'z').ofMaxLength(20)).sample();
+		HttpEntity<CertificationRequest> entity = new HttpEntity<>(request, httpHeaders);
+
+		final ResponseEntity<ApiResponse> responseEntity = restTemplate.postForEntity(uriComponents.toUriString(), entity, ApiResponse.class);
+		final ApiResponse response = objectMapper.convertValue(responseEntity.getBody(), ApiResponse.class);
+
+		assertEquals(HttpStatusCode.valueOf(200), responseEntity.getStatusCode());
+		assertEquals(ReturnCode.SUCCESS.getCode(), response.getReturnCode());
+		assertEquals(ReturnCode.SUCCESS.getMessage(), response.getReturnMessage());
+	}
+
+	@TestWithDisplayName("로그인한 사용자는 자신의 케이크샵이 존재하지 않은 상태에서 사장님 인증을 요청한다")
+	void request2() {
+		final String url = "%s%d%s".formatted(BASE_URL, port, API_URL);
+		final UriComponents uriComponents = UriComponentsBuilder
+			.fromUriString(url)
+			.path("/certification")
+			.build();
+		User user = userReader.findByUserId(1L);
+
+		JsonWebToken jsonWebToken = jwtProvider.generateToken(user);
+		HttpHeaders httpHeaders = new HttpHeaders();
+		httpHeaders.add(HttpHeaders.AUTHORIZATION, "Bearer " + jsonWebToken.accessToken());
+		CertificationRequest request = getConstructorMonkey().giveMeBuilder(CertificationRequest.class)
+			.set("businessRegistrationImageUrl", Arbitraries.strings().withCharRange('a', 'z').ofMaxLength(40))
+			.set("idCardImageUrl", Arbitraries.strings().withCharRange('a', 'z').ofMaxLength(40))
+			.set("cakeShopId", Arbitraries.longs().greaterOrEqual(1).lessOrEqual(3))
+			.set("emergencyContact", Arbitraries.strings().withCharRange('a', 'z').ofMaxLength(11))
+			.set("message", Arbitraries.strings().withCharRange('a', 'z').ofMaxLength(20)).sample();
+		HttpEntity<CertificationRequest> entity = new HttpEntity<>(request, httpHeaders);
+
+		final ResponseEntity<ApiResponse> responseEntity = restTemplate.postForEntity(uriComponents.toUriString(), entity, ApiResponse.class);
+		final ApiResponse response = objectMapper.convertValue(responseEntity.getBody(), ApiResponse.class);
+
+		assertEquals(HttpStatusCode.valueOf(200), responseEntity.getStatusCode());
+		assertEquals(ReturnCode.SUCCESS.getCode(), response.getReturnCode());
+		assertEquals(ReturnCode.SUCCESS.getMessage(), response.getReturnMessage());
+	}
 }

--- a/cakk-api/src/test/java/com/cakk/api/service/shop/ShopServiceTest.java
+++ b/cakk-api/src/test/java/com/cakk/api/service/shop/ShopServiceTest.java
@@ -74,7 +74,7 @@ public class ShopServiceTest extends ServiceTest {
 	private CreateShopRequest getCreateShopRequestFixture() {
 		return getConstructorMonkey().giveMeBuilder(CreateShopRequest.class)
 			.set("businessNumber", Arbitraries.strings().withCharRange('a', 'z').ofMinLength(1).ofMaxLength(7))
-			.set("operationDays", getOperationDayFixture())
+			.set("operationDayRequest", getOperationDayFixture())
 			.set("shopName", Arbitraries.strings().withCharRange('a', 'z').ofMinLength(1).ofMaxLength(20))
 			.set("shopBio", Arbitraries.strings().withCharRange('a', 'z').ofMaxLength(20))
 			.set("shopDescription", Arbitraries.strings().withCharRange('a', 'z').ofMaxLength(20))

--- a/cakk-api/src/test/java/com/cakk/api/service/shop/ShopServiceTest.java
+++ b/cakk-api/src/test/java/com/cakk/api/service/shop/ShopServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.*;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
+import java.time.LocalTime;
 import java.util.Set;
 
 import org.junit.jupiter.api.DisplayName;
@@ -21,6 +22,7 @@ import com.cakk.api.dto.request.shop.PromotionRequest;
 import com.cakk.api.dto.response.shop.CakeShopDetailResponse;
 import com.cakk.api.dto.response.shop.CakeShopSimpleResponse;
 import com.cakk.api.mapper.ShopMapper;
+import com.cakk.common.enums.Days;
 import com.cakk.common.enums.ReturnCode;
 import com.cakk.common.exception.CakkException;
 import com.cakk.domain.dto.param.shop.CakeShopDetailParam;
@@ -58,7 +60,8 @@ public class ShopServiceTest extends ServiceTest {
 		return getConstructorMonkey().giveMeBuilder(OperationDay.class)
 			.set("days", Arbitraries.of(Days.class).list().ofSize(7))
 			.set("startTimes",
-				Arbitraries.of(LocalTime.of(Arbitraries.integers().greaterOrEqual(0).lessOrEqual(23).sample(), Arbitraries.integers().greaterOrEqual(0).lessOrEqual(59).sample()))
+				Arbitraries.of(
+						LocalTime.of(Arbitraries.integers().greaterOrEqual(0).lessOrEqual(23).sample(), Arbitraries.integers().greaterOrEqual(0).lessOrEqual(59).sample()))
 					.list()
 					.ofSize(7))
 			.set("endTimes",

--- a/cakk-api/src/test/java/com/cakk/api/service/shop/ShopServiceTest.java
+++ b/cakk-api/src/test/java/com/cakk/api/service/shop/ShopServiceTest.java
@@ -17,18 +17,24 @@ import com.cakk.api.common.annotation.TestWithDisplayName;
 import com.cakk.api.common.base.ServiceTest;
 import com.cakk.api.dto.request.shop.CreateShopRequest;
 import com.cakk.api.dto.request.shop.OperationDay;
+import com.cakk.api.dto.request.shop.PromotionRequest;
 import com.cakk.api.dto.response.shop.CakeShopDetailResponse;
 import com.cakk.api.dto.response.shop.CakeShopSimpleResponse;
 import com.cakk.api.mapper.ShopMapper;
 import com.cakk.common.enums.ReturnCode;
 import com.cakk.common.exception.CakkException;
 import com.cakk.domain.dto.param.shop.CakeShopDetailParam;
+import com.cakk.domain.dto.param.user.CertificationParam;
 import com.cakk.domain.entity.shop.CakeShop;
 import com.cakk.domain.entity.user.BusinessInformation;
+import com.cakk.domain.entity.user.User;
+import com.cakk.domain.event.shop.CertificationEvent;
 import com.cakk.domain.dto.param.shop.CakeShopSimpleParam;
 import com.cakk.domain.repository.reader.CakeShopReader;
 import com.cakk.domain.repository.reader.UserReader;
 import com.cakk.domain.repository.writer.CakeShopWriter;
+
+import com.navercorp.fixturemonkey.ArbitraryBuilder;
 
 @DisplayName("케이크 샵 조회 관련 비즈니스 로직 테스트")
 public class ShopServiceTest extends ServiceTest {
@@ -70,6 +76,21 @@ public class ShopServiceTest extends ServiceTest {
 			.set("shopBio", Arbitraries.strings().withCharRange('a', 'z').ofMaxLength(20))
 			.set("shopDescription", Arbitraries.strings().withCharRange('a', 'z').ofMaxLength(20))
 			.sample();
+	}
+
+	private PromotionRequest getPromotionRequestFixture() {
+		return getConstructorMonkey().giveMeBuilder(PromotionRequest.class)
+			.set("userId", Arbitraries.longs().greaterOrEqual(0))
+			.set("cakeShopId", Arbitraries.longs().greaterOrEqual(0))
+			.sample();
+	}
+
+	private CertificationParam getCertificationParamFixture(boolean isNull) {
+		ArbitraryBuilder<CertificationParam> builder = getConstructorMonkey().giveMeBuilder(CertificationParam.class);
+		if (isNull) {
+			return builder.setNull("cakeShopId").setNotNull("user").sample();
+		}
+		return builder.setNotNull("cakeShopId").setNotNull("user").sample();
 	}
 
 	@TestWithDisplayName("id로 케이크 샵을 간단조회 한다.")
@@ -162,5 +183,21 @@ public class ShopServiceTest extends ServiceTest {
 		//verify
 		verify(cakeShopWriter, times(1))
 			.createCakeShop(any(CakeShop.class), anyList(), any(BusinessInformation.class));
+	}
+
+	@TestWithDisplayName("userId와 cakeShopId가 존재한다면, 해당 userId의 사용자는 Owner로 승격된다")
+	void promoteUser() {
+		//given
+		PromotionRequest request = getPromotionRequestFixture();
+		doReturn(getReflectionMonkey().giveMeOne(User.class)).when(userReader).findByUserId(request.userId());
+		doReturn(getReflectionMonkey().giveMeBuilder(BusinessInformation.class).setNotNull("cakeShop").sample())
+			.when(cakeShopReader).findBusinessInformationWithShop(request.cakeShopId());
+
+		//when,then
+		shopService.promoteUserToBusinessOwner(request);
+
+		//verify
+		verify(userReader, times(1)).findByUserId(request.userId());
+		verify(cakeShopReader, times(1)).findBusinessInformationWithShop(request.cakeShopId());
 	}
 }

--- a/cakk-api/src/test/java/com/cakk/api/service/shop/ShopServiceTest.java
+++ b/cakk-api/src/test/java/com/cakk/api/service/shop/ShopServiceTest.java
@@ -15,12 +15,15 @@ import net.jqwik.api.Arbitraries;
 
 import com.cakk.api.common.annotation.TestWithDisplayName;
 import com.cakk.api.common.base.ServiceTest;
+import com.cakk.api.dto.request.shop.CreateShopRequest;
 import com.cakk.api.dto.response.shop.CakeShopDetailResponse;
 import com.cakk.api.dto.response.shop.CakeShopSimpleResponse;
 import com.cakk.api.mapper.ShopMapper;
 import com.cakk.common.enums.ReturnCode;
 import com.cakk.common.exception.CakkException;
 import com.cakk.domain.dto.param.shop.CakeShopDetailParam;
+import com.cakk.domain.entity.shop.CakeShop;
+import com.cakk.domain.entity.user.BusinessInformation;
 import com.cakk.domain.dto.param.shop.CakeShopSimpleParam;
 import com.cakk.domain.repository.reader.CakeShopReader;
 import com.cakk.domain.repository.reader.UserReader;
@@ -43,6 +46,18 @@ public class ShopServiceTest extends ServiceTest {
 
 	@Mock
 	private ApplicationEventPublisher publisher;
+
+	private CreateShopRequest getCreateShopRequestFixture() {
+		return getConstructorMonkey().giveMeBuilder(CreateShopRequest.class)
+			.set("businessNumber", Arbitraries.strings().withCharRange('a', 'z').ofMinLength(1).ofMaxLength(7))
+			.set("shopName", Arbitraries.strings().withCharRange('a', 'z').ofMinLength(1).ofMaxLength(20))
+			.set("shopBio", Arbitraries.strings().withCharRange('a', 'z').ofMaxLength(20))
+			.set("shopDescription", Arbitraries.strings().withCharRange('a', 'z').ofMaxLength(20))
+			.set("startTimes", Arbitraries.of(LocalTime.now()).list().ofSize(3))
+			.set("endTimes", Arbitraries.of(LocalTime.now()).list().ofSize(3))
+			.set("operationsDays", Arbitraries.of(Days.class).list().ofSize(3))
+			.sample();
+	}
 
 	@TestWithDisplayName("id로 케이크 샵을 간단조회 한다.")
 	void searchSimpleById1() {
@@ -121,5 +136,19 @@ public class ShopServiceTest extends ServiceTest {
 			.hasMessageContaining(ReturnCode.NOT_EXIST_CAKE_SHOP.getMessage());
 
 		verify(cakeShopReader, times(1)).searchDetailById(cakeShopId);
+	}
+
+	@TestWithDisplayName("Admin에 의해 케이크 샵을 생성하는데 성공한다")
+	void createCakeShop() {
+		//given
+		CreateShopRequest request = getCreateShopRequestFixture();
+		System.out.println(request);
+
+		//when
+		shopService.createCakeShopByCertification(request);
+
+		//verify
+		verify(cakeShopWriter, times(1))
+			.createCakeShop(any(CakeShop.class), anyList(), any(BusinessInformation.class));
 	}
 }

--- a/cakk-api/src/test/java/com/cakk/api/service/shop/ShopServiceTest.java
+++ b/cakk-api/src/test/java/com/cakk/api/service/shop/ShopServiceTest.java
@@ -17,7 +17,7 @@ import net.jqwik.api.Arbitraries;
 import com.cakk.api.common.annotation.TestWithDisplayName;
 import com.cakk.api.common.base.ServiceTest;
 import com.cakk.api.dto.request.shop.CreateShopRequest;
-import com.cakk.api.dto.request.shop.OperationDay;
+import com.cakk.api.dto.request.shop.OperationDayRequest;
 import com.cakk.api.dto.request.shop.PromotionRequest;
 import com.cakk.api.dto.response.shop.CakeShopDetailResponse;
 import com.cakk.api.dto.response.shop.CakeShopSimpleResponse;
@@ -56,8 +56,8 @@ public class ShopServiceTest extends ServiceTest {
 	@Mock
 	private ApplicationEventPublisher publisher;
 
-	private OperationDay getOperationDayFixture() {
-		return getConstructorMonkey().giveMeBuilder(OperationDay.class)
+	private OperationDayRequest getOperationDayFixture() {
+		return getConstructorMonkey().giveMeBuilder(OperationDayRequest.class)
 			.set("days", Arbitraries.of(Days.class).list().ofSize(7))
 			.set("startTimes",
 				Arbitraries.of(

--- a/cakk-api/src/test/java/com/cakk/api/service/shop/ShopServiceTest.java
+++ b/cakk-api/src/test/java/com/cakk/api/service/shop/ShopServiceTest.java
@@ -16,6 +16,7 @@ import net.jqwik.api.Arbitraries;
 import com.cakk.api.common.annotation.TestWithDisplayName;
 import com.cakk.api.common.base.ServiceTest;
 import com.cakk.api.dto.request.shop.CreateShopRequest;
+import com.cakk.api.dto.request.shop.OperationDay;
 import com.cakk.api.dto.response.shop.CakeShopDetailResponse;
 import com.cakk.api.dto.response.shop.CakeShopSimpleResponse;
 import com.cakk.api.mapper.ShopMapper;
@@ -47,15 +48,27 @@ public class ShopServiceTest extends ServiceTest {
 	@Mock
 	private ApplicationEventPublisher publisher;
 
+	private OperationDay getOperationDayFixture() {
+		return getConstructorMonkey().giveMeBuilder(OperationDay.class)
+			.set("days", Arbitraries.of(Days.class).list().ofSize(7))
+			.set("startTimes",
+				Arbitraries.of(LocalTime.of(Arbitraries.integers().greaterOrEqual(0).lessOrEqual(23).sample(), Arbitraries.integers().greaterOrEqual(0).lessOrEqual(59).sample()))
+					.list()
+					.ofSize(7))
+			.set("endTimes",
+				Arbitraries.of(LocalTime.of(Arbitraries.integers().greaterOrEqual(0).lessOrEqual(23).sample(), Arbitraries.integers().greaterOrEqual(0).lessOrEqual(59).sample()))
+					.list()
+					.ofSize(7))
+			.sample();
+	}
+
 	private CreateShopRequest getCreateShopRequestFixture() {
 		return getConstructorMonkey().giveMeBuilder(CreateShopRequest.class)
 			.set("businessNumber", Arbitraries.strings().withCharRange('a', 'z').ofMinLength(1).ofMaxLength(7))
+			.set("operationDays", getOperationDayFixture())
 			.set("shopName", Arbitraries.strings().withCharRange('a', 'z').ofMinLength(1).ofMaxLength(20))
 			.set("shopBio", Arbitraries.strings().withCharRange('a', 'z').ofMaxLength(20))
 			.set("shopDescription", Arbitraries.strings().withCharRange('a', 'z').ofMaxLength(20))
-			.set("startTimes", Arbitraries.of(LocalTime.now()).list().ofSize(3))
-			.set("endTimes", Arbitraries.of(LocalTime.now()).list().ofSize(3))
-			.set("operationsDays", Arbitraries.of(Days.class).list().ofSize(3))
 			.sample();
 	}
 
@@ -142,7 +155,6 @@ public class ShopServiceTest extends ServiceTest {
 	void createCakeShop() {
 		//given
 		CreateShopRequest request = getCreateShopRequestFixture();
-		System.out.println(request);
 
 		//when
 		shopService.createCakeShopByCertification(request);

--- a/cakk-api/src/test/java/com/cakk/api/service/shop/ShopServiceTest.java
+++ b/cakk-api/src/test/java/com/cakk/api/service/shop/ShopServiceTest.java
@@ -200,4 +200,35 @@ public class ShopServiceTest extends ServiceTest {
 		verify(userReader, times(1)).findByUserId(request.userId());
 		verify(cakeShopReader, times(1)).findBusinessInformationWithShop(request.cakeShopId());
 	}
+
+	@TestWithDisplayName("cakeShopId가 존재한다면, 정보를 찾아서 이벤트를 발행한다")
+	void requestCertificationEventWithInfo() {
+		//given
+		CertificationParam param = getCertificationParamFixture(false);
+		doReturn(getReflectionMonkey().giveMeBuilder(BusinessInformation.class)
+			.setNotNull("cakeShop")
+			.setNull("user")
+			.sample())
+			.when(cakeShopReader).findBusinessInformationByCakeShopId(param.cakeShopId());
+
+		//when
+		shopService.requestCertificationBusinessOwner(param);
+
+		//verify
+		verify(cakeShopReader, times(1)).findBusinessInformationByCakeShopId(param.cakeShopId());
+		verify(publisher, times(1)).publishEvent(any(CertificationEvent.class));
+	}
+
+	@TestWithDisplayName("cakeShopId가 존재하지 않는다면, 요청 정보로만 이벤트를 발행한다")
+	void requestCertificationEventWithParam() {
+		//given
+		CertificationParam param = getCertificationParamFixture(true);
+
+		//when
+		shopService.requestCertificationBusinessOwner(param);
+
+		//verify
+		verify(cakeShopReader, times(0)).findBusinessInformationByCakeShopId(any());
+		verify(publisher, times(1)).publishEvent(any(CertificationEvent.class));
+	}
 }

--- a/cakk-api/src/test/resources/application-test.yml
+++ b/cakk-api/src/test/resources/application-test.yml
@@ -6,7 +6,7 @@ spring:
   jpa:
     hibernate:
       ddl-auto: create
-    show-sql: true
+    show-sql: false
   flyway:
     enabled: false
 

--- a/cakk-api/src/test/resources/sql/insert-cake-shop.sql
+++ b/cakk-api/src/test/resources/sql/insert-cake-shop.sql
@@ -24,3 +24,8 @@ values (1, 1, 'web', 'https://www.cake-shop1.com', now(), now()),
        (5, 2, 'instagram', 'https://www.instagram.com/cake-shop2', now(), now()),
        (6, 3, 'web', 'https://www.cake-shop3.com', now(), now()),
        (7, 3, 'kakaotalk', 'https://www.kakaotalk.com/cake-shop3', now(), now());
+
+insert into business_information(business_number, shop_id, user_id)
+values ('010-3375-5555', 1, 1),
+       ('010-3375-5555', 2, 2),
+       ('010-3375-5555', 3, 3)

--- a/cakk-api/src/test/resources/sql/insert-test-user.sql
+++ b/cakk-api/src/test/resources/sql/insert-test-user.sql
@@ -1,3 +1,5 @@
 insert into users (user_id, provider, provider_id, nickname, profile_image_url, email, gender, birthday, role, created_at, updated_at,
                    deleted_at)
-values (1, 'GOOGLE', '123456', '테스트 유저', 'image_url', 'test@google.com', 'MALE', '1998-01-01', 'USER', now(), now(), null);
+values (1, 'GOOGLE', '123456', '테스트 유저1', 'image_url1', 'test1@google.com', 'MALE', '1998-01-01', 'USER', now(), now(), null),
+       (2, 'GOOGLE', '123457', '테스트 유저2', 'image_url2', 'test2@google.com', 'MALE', '1998-01-02', 'USER', now(), now(), null),
+       (3, 'GOOGLE', '123458', '테스트 유저3', 'image_url3', 'test3@google.com', 'MALE', '1998-01-03', 'USER', now(), now(), null);

--- a/cakk-common/src/main/java/com/cakk/common/enums/ReturnCode.java
+++ b/cakk-common/src/main/java/com/cakk/common/enums/ReturnCode.java
@@ -15,6 +15,7 @@ public enum ReturnCode {
 	EXPIRED_JWT_TOKEN("1102", "만료된 jwt 토큰입니다."),
 	EMPTY_AUTH_JWT("1103", "인증 정보가 비어있는 jwt 토큰입니다."),
 	EMPTY_USER("1104", "비어있는 유저 정보로 jwt 토큰을 생성할 수 없습니다."),
+	INVALID_KEY("1105", "잘못된 key 입니다"),
 
 	// 공통 유저 관련 (1200 ~ 1250)
 	WRONG_PROVIDER("1200", "잘못된 인증 제공자 입니다."),

--- a/cakk-domain/build.gradle
+++ b/cakk-domain/build.gradle
@@ -5,7 +5,6 @@ dependencies {
 
     // jpa
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-json'
 	implementation 'io.hypersistence:hypersistence-utils-hibernate-63:3.7.4'
 
 	// test
@@ -23,6 +22,10 @@ dependencies {
     // database
     runtimeOnly 'com.mysql:mysql-connector-j:8.2.0'
     runtimeOnly 'com.h2database:h2'
+
+	//serialize
+	implementation('com.fasterxml.jackson.datatype:jackson-datatype-jsr310')
+	implementation('com.fasterxml.jackson.core:jackson-databind')
 
 	// log
 	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'

--- a/cakk-domain/build.gradle
+++ b/cakk-domain/build.gradle
@@ -5,6 +5,7 @@ dependencies {
 
     // jpa
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-json'
 	implementation 'io.hypersistence:hypersistence-utils-hibernate-63:3.7.4'
 
 	// test

--- a/cakk-domain/src/main/java/com/cakk/domain/config/JacksonConfig.java
+++ b/cakk-domain/src/main/java/com/cakk/domain/config/JacksonConfig.java
@@ -1,0 +1,20 @@
+package com.cakk.domain.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+@Configuration
+public class JacksonConfig {
+
+	@Bean
+	public ObjectMapper objectMapper() {
+		ObjectMapper objectMapper = new ObjectMapper();
+		objectMapper.registerModule(new JavaTimeModule());
+		objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+		return objectMapper;
+	}
+}

--- a/cakk-domain/src/main/java/com/cakk/domain/entity/audit/AuditEntity.java
+++ b/cakk-domain/src/main/java/com/cakk/domain/entity/audit/AuditEntity.java
@@ -10,6 +10,11 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+
 import lombok.Getter;
 
 @Getter
@@ -17,10 +22,14 @@ import lombok.Getter;
 @EntityListeners(AuditingEntityListener.class)
 public class AuditEntity {
 
+	@JsonSerialize(using = LocalDateTimeSerializer.class)
+	@JsonDeserialize(using = LocalDateTimeDeserializer.class)
 	@CreatedDate
 	@Column(updatable = false)
 	private LocalDateTime createdAt;
 
+	@JsonSerialize(using = LocalDateTimeSerializer.class)
+	@JsonDeserialize(using = LocalDateTimeDeserializer.class)
 	@LastModifiedDate
 	@Column
 	private LocalDateTime updatedAt;

--- a/cakk-domain/src/main/java/com/cakk/domain/entity/user/User.java
+++ b/cakk-domain/src/main/java/com/cakk/domain/entity/user/User.java
@@ -23,6 +23,12 @@ import com.cakk.common.enums.Gender;
 import com.cakk.common.enums.Provider;
 import com.cakk.common.enums.Role;
 import com.cakk.domain.entity.audit.AuditEntity;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -55,6 +61,8 @@ public class User extends AuditEntity {
 	@Column(name = "gender", length = 7, nullable = false)
 	private Gender gender;
 
+	@JsonSerialize(using = LocalDateSerializer.class)
+	@JsonDeserialize(using = LocalDateDeserializer.class)
 	@Column(name = "birthday")
 	private LocalDate birthday;
 

--- a/cakk-domain/src/main/java/com/cakk/domain/entity/user/User.java
+++ b/cakk-domain/src/main/java/com/cakk/domain/entity/user/User.java
@@ -14,6 +14,11 @@ import jakarta.persistence.Table;
 
 import org.hibernate.annotations.ColumnDefault;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
+
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -23,12 +28,6 @@ import com.cakk.common.enums.Gender;
 import com.cakk.common.enums.Provider;
 import com.cakk.common.enums.Role;
 import com.cakk.domain.entity.audit.AuditEntity;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
-import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
-import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
-import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)


### PR DESCRIPTION
> ### Issue Number

#42 

> ### Description

- [6b2f8ce](https://github.com/CAKK-DEV/cakk-server/pull/45/commits/6b2f8cec8821f55b54da06974347f4d641a70631) 영업 정보 POST시, 영업일자, 시간들에 대해 데이터 입력이 빠질 경우, RuntimeException이 발생하기 때문에 하나의 데이터로 통합했습니다
- 사용자 권한이 필요한 Post 요청 시, 통합 테스트 진행을 위해 SQL Script 순서 변경 및 데이터 추가가 있습니다
- 통합 테스트에서 발생한 오류를 보기 위해 Debug Level에서 log가 출력됩니다
- 토큰 관련해서 직렬화 및 역 직렬화 설정 추가했습니다

> ### Core Code
[93a0021](https://github.com/CAKK-DEV/cakk-server/pull/45/commits/93a0021c880e2a5679812ea27a8f15b7e6eb1ae5)
RequestBody에서 Validation Annotation에 의해 실패할 수 있는 최소 길이 설정이 꼭 필요함을 주의해야 합니다
```java

```

> ### etc
