### PR TITLE
Feature: 케이크 샵 상세 정보 조회 구현

### DIFF
--- a/cakk-api/src/main/java/com/cakk/api/controller/shop/ShopController.java
+++ b/cakk-api/src/main/java/com/cakk/api/controller/shop/ShopController.java
@@ -17,6 +17,7 @@ import com.cakk.api.dto.request.shop.CreateShopRequest;
 import com.cakk.api.dto.request.shop.PromotionRequest;
 import com.cakk.api.dto.request.user.CertificationRequest;
 import com.cakk.api.dto.response.shop.CakeShopDetailResponse;
+import com.cakk.api.dto.response.shop.CakeShopInfoResponse;
 import com.cakk.api.dto.response.shop.CakeShopSimpleResponse;
 import com.cakk.api.service.shop.ShopService;
 import com.cakk.common.response.ApiResponse;
@@ -66,6 +67,14 @@ public class ShopController {
 		@PathVariable Long cakeShopId
 	) {
 		final CakeShopDetailResponse response = shopService.searchDetailById(cakeShopId);
+		return ApiResponse.success(response);
+	}
+
+	@GetMapping("/{cakeShopId}/info")
+	public ApiResponse<CakeShopInfoResponse> detailInfo(
+		@PathVariable Long cakeShopId
+	) {
+		final CakeShopInfoResponse response = shopService.searchInfoById(cakeShopId);
 		return ApiResponse.success(response);
 	}
 }

--- a/cakk-api/src/main/java/com/cakk/api/dto/response/shop/CakeShopInfoResponse.java
+++ b/cakk-api/src/main/java/com/cakk/api/dto/response/shop/CakeShopInfoResponse.java
@@ -1,0 +1,13 @@
+package com.cakk.api.dto.response.shop;
+
+import java.util.List;
+
+import com.cakk.domain.dto.param.shop.CakeShopOperationParam;
+
+public record CakeShopInfoResponse(
+	String shopAddress,
+	Double latitude,
+	Double longitude,
+	List<CakeShopOperationParam> shopOperationDays
+) {
+}

--- a/cakk-api/src/main/java/com/cakk/api/mapper/ShopMapper.java
+++ b/cakk-api/src/main/java/com/cakk/api/mapper/ShopMapper.java
@@ -9,9 +9,11 @@ import lombok.NoArgsConstructor;
 
 import com.cakk.api.dto.request.shop.CreateShopRequest;
 import com.cakk.api.dto.response.shop.CakeShopDetailResponse;
+import com.cakk.api.dto.response.shop.CakeShopInfoResponse;
 import com.cakk.api.dto.response.shop.CakeShopSimpleResponse;
 import com.cakk.common.enums.Days;
 import com.cakk.domain.dto.param.shop.CakeShopDetailParam;
+import com.cakk.domain.dto.param.shop.CakeShopInfoParam;
 import com.cakk.domain.dto.param.shop.CakeShopSimpleParam;
 import com.cakk.domain.entity.shop.CakeShop;
 import com.cakk.domain.entity.shop.CakeShopOperation;
@@ -82,5 +84,14 @@ public class ShopMapper {
 			.operationDays(param.operationDays())
 			.links(param.links())
 			.build();
+	}
+
+	public static CakeShopInfoResponse supplyCakeShopInfoResponseBy(CakeShopInfoParam param) {
+		return new CakeShopInfoResponse(
+			param.shopAddress(),
+			param.latitude(),
+			param.longitude(),
+			param.shopOperationDays()
+		);
 	}
 }

--- a/cakk-api/src/main/java/com/cakk/api/service/shop/ShopService.java
+++ b/cakk-api/src/main/java/com/cakk/api/service/shop/ShopService.java
@@ -12,9 +12,11 @@ import com.cakk.api.dto.request.shop.CreateShopRequest;
 import com.cakk.api.dto.request.shop.OperationDayRequest;
 import com.cakk.api.dto.request.shop.PromotionRequest;
 import com.cakk.api.dto.response.shop.CakeShopDetailResponse;
+import com.cakk.api.dto.response.shop.CakeShopInfoResponse;
 import com.cakk.api.dto.response.shop.CakeShopSimpleResponse;
 import com.cakk.api.mapper.ShopMapper;
 import com.cakk.domain.dto.param.shop.CakeShopDetailParam;
+import com.cakk.domain.dto.param.shop.CakeShopInfoParam;
 import com.cakk.domain.dto.param.shop.CakeShopSimpleParam;
 import com.cakk.domain.dto.param.user.CertificationParam;
 import com.cakk.domain.entity.shop.CakeShop;
@@ -87,5 +89,12 @@ public class ShopService {
 		final CakeShopDetailParam cakeShop = cakeShopReader.searchDetailById(cakeShopId);
 
 		return ShopMapper.cakeShopDetailResponseFromParam(cakeShop);
+	}
+
+	@Transactional(readOnly = true)
+	public CakeShopInfoResponse searchInfoById(final Long cakeShopId) {
+		final CakeShopInfoParam cakeShopInfo = cakeShopReader.searchInfoById(cakeShopId);
+
+		return ShopMapper.supplyCakeShopInfoResponseBy(cakeShopInfo);
 	}
 }

--- a/cakk-api/src/test/java/com/cakk/api/integration/shop/ShopIntegrationTest.java
+++ b/cakk-api/src/test/java/com/cakk/api/integration/shop/ShopIntegrationTest.java
@@ -3,6 +3,7 @@ package com.cakk.api.integration.shop;
 import static org.junit.Assert.*;
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.*;
 
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,13 +22,16 @@ import com.cakk.api.common.annotation.TestWithDisplayName;
 import com.cakk.api.common.base.IntegrationTest;
 import com.cakk.api.dto.request.user.CertificationRequest;
 import com.cakk.api.dto.response.shop.CakeShopDetailResponse;
+import com.cakk.api.dto.response.shop.CakeShopInfoResponse;
 import com.cakk.api.dto.response.shop.CakeShopSimpleResponse;
 import com.cakk.api.provider.jwt.JwtProvider;
 import com.cakk.api.vo.JsonWebToken;
 import com.cakk.common.enums.Days;
 import com.cakk.common.enums.ReturnCode;
 import com.cakk.common.response.ApiResponse;
+import com.cakk.domain.dto.param.shop.CakeShopInfoParam;
 import com.cakk.domain.dto.param.shop.CakeShopLinkParam;
+import com.cakk.domain.dto.param.shop.CakeShopOperationParam;
 import com.cakk.domain.entity.shop.CakeShop;
 import com.cakk.domain.entity.shop.CakeShopOperation;
 import com.cakk.domain.entity.user.User;
@@ -219,5 +223,56 @@ public class ShopIntegrationTest extends IntegrationTest {
 		assertEquals(HttpStatusCode.valueOf(200), responseEntity.getStatusCode());
 		assertEquals(ReturnCode.SUCCESS.getCode(), response.getReturnCode());
 		assertEquals(ReturnCode.SUCCESS.getMessage(), response.getReturnMessage());
+	}
+
+	@TestWithDisplayName("케이크 샵의 상세 정보 조회에 성공한다.")
+	void detailInfo1() {
+		final String url = "%s%d%s".formatted(BASE_URL, port, API_URL);
+		final Long cakeShopId = 1L;
+		final UriComponents uriComponents = UriComponentsBuilder
+			.fromUriString(url)
+			.path("/{cakeShopId}/info")
+			.buildAndExpand(cakeShopId);
+
+		// when
+		final ResponseEntity<ApiResponse> responseEntity = restTemplate.getForEntity(uriComponents.toUriString(), ApiResponse.class);
+
+		// then
+		final ApiResponse response = objectMapper.convertValue(responseEntity.getBody(), ApiResponse.class);
+		final CakeShopInfoResponse data = objectMapper.convertValue(response.getData(), CakeShopInfoResponse.class);
+
+		assertEquals(HttpStatusCode.valueOf(200), responseEntity.getStatusCode());
+		assertEquals(ReturnCode.SUCCESS.getCode(), response.getReturnCode());
+		assertEquals(ReturnCode.SUCCESS.getMessage(), response.getReturnMessage());
+
+		final CakeShop cakeShop = cakeShopReader.findById(cakeShopId);
+		assertEquals(cakeShop.getShopAddress(), data.shopAddress());
+		assertEquals(cakeShop.getLatitude(), data.latitude());
+		assertEquals(cakeShop.getLongitude(), data.longitude());
+
+		List<CakeShopOperationParam> cakeShopOperations = cakeShopOperationReader.findAllByCakeShopId(cakeShopId).stream()
+			.map((it) -> new CakeShopOperationParam(it.getOperationDay(), it.getOperationStartTime(), it.getOperationEndTime()))
+			.toList();
+		assertEquals(cakeShopOperations, data.shopOperationDays());
+	}
+
+	@TestWithDisplayName("없는 케이크 샵일 경우, 상세정보 조회에 실패한다.")
+	void detailInfo2() {
+		final String url = "%s%d%s".formatted(BASE_URL, port, API_URL);
+		final Long cakeShopId = 1000L;
+		final UriComponents uriComponents = UriComponentsBuilder
+			.fromUriString(url)
+			.path("/{cakeShopId}/info")
+			.buildAndExpand(cakeShopId);
+
+		// when
+		final ResponseEntity<ApiResponse> responseEntity = restTemplate.getForEntity(uriComponents.toUriString(), ApiResponse.class);
+
+		// then
+		final ApiResponse response = objectMapper.convertValue(responseEntity.getBody(), ApiResponse.class);
+
+		assertEquals(HttpStatusCode.valueOf(400), responseEntity.getStatusCode());
+		assertEquals(ReturnCode.NOT_EXIST_CAKE_SHOP.getCode(), response.getReturnCode());
+		assertEquals(ReturnCode.NOT_EXIST_CAKE_SHOP.getMessage(), response.getReturnMessage());
 	}
 }

--- a/cakk-api/src/test/resources/sql/insert-cake-shop.sql
+++ b/cakk-api/src/test/resources/sql/insert-cake-shop.sql
@@ -1,8 +1,8 @@
-insert into cake_shop (shop_id, thumbnail_url, shop_name, shop_bio, shop_description, latitude, longitude, like_count, linked_flag,
+insert into cake_shop (shop_id, thumbnail_url, shop_name, shop_address, shop_bio, shop_description, latitude, longitude, like_count, linked_flag,
                        created_at, updated_at)
-values (1, 'thumbnail_url1', '케이크 맛집1', '케이크 맛집입니다.', '케이크 맛집입니다.', 37.123456, 127.123456, 0, false, now(), now()),
-       (2, 'thumbnail_url2', '케이크 맛집2', '케이크 맛집입니다.', '케이크 맛집입니다.', 38.123456, 128.123456, 0, false, now(), now()),
-       (3, 'thumbnail_url3', '케이크 맛집3', '케이크 맛집입니다.', '케이크 맛집입니다.', 39.123456, 129.123456, 0, false, now(), now());
+values (1, 'thumbnail_url1', '케이크 맛집1', '케이크 맛집입니다.', '서울시 강남구 어쩌고로1', '케이크 맛집입니다.', 37.123456, 127.123456, 0, false, now(), now()),
+       (2, 'thumbnail_url2', '케이크 맛집2', '케이크 맛집입니다.', '서울시 강남구 어쩌고로2', '케이크 맛집입니다.', 38.123456, 128.123456, 0, false, now(), now()),
+       (3, 'thumbnail_url3', '케이크 맛집3', '케이크 맛집입니다.', '서울시 강남구 어쩌고로3', '케이크 맛집입니다.', 39.123456, 129.123456, 0, false, now(), now());
 
 insert into cake_shop_operation (operation_id, shop_id, operation_day, start_time, end_time, created_at, updated_at)
 values (1, 1, 0, '10:00:00', '22:00:00', now(), now()),

--- a/cakk-domain/src/main/java/com/cakk/domain/dto/param/shop/CakeShopInfoParam.java
+++ b/cakk-domain/src/main/java/com/cakk/domain/dto/param/shop/CakeShopInfoParam.java
@@ -1,0 +1,11 @@
+package com.cakk.domain.dto.param.shop;
+
+import java.util.List;
+
+public record CakeShopInfoParam(
+	String shopAddress,
+	Double latitude,
+	Double longitude,
+	List<CakeShopOperationParam> shopOperationDays
+) {
+}

--- a/cakk-domain/src/main/java/com/cakk/domain/dto/param/shop/CakeShopOperationParam.java
+++ b/cakk-domain/src/main/java/com/cakk/domain/dto/param/shop/CakeShopOperationParam.java
@@ -1,0 +1,12 @@
+package com.cakk.domain.dto.param.shop;
+
+import java.time.LocalTime;
+
+import com.cakk.common.enums.Days;
+
+public record CakeShopOperationParam(
+	Days operationDay,
+	LocalTime operationStartTime,
+	LocalTime operationEndTime
+) {
+}

--- a/cakk-domain/src/main/java/com/cakk/domain/entity/shop/CakeShop.java
+++ b/cakk-domain/src/main/java/com/cakk/domain/entity/shop/CakeShop.java
@@ -35,6 +35,9 @@ public class CakeShop extends AuditEntity {
 	@Column(name = "shop_name", length = 30, nullable = false)
 	private String shopName;
 
+	@Column(name = "shop_address", length = 50)
+	private String shopAddress;
+
 	@Column(name = "shop_bio", length = 40)
 	private String shopBio;
 
@@ -63,6 +66,7 @@ public class CakeShop extends AuditEntity {
 	public CakeShop(
 		String shopName,
 		String thumbnailUrl,
+		String shopAddress,
 		String shopBio,
 		String shopDescription,
 		Double latitude,
@@ -70,6 +74,7 @@ public class CakeShop extends AuditEntity {
 	) {
 		this.shopName = shopName;
 		this.thumbnailUrl = thumbnailUrl;
+		this.shopAddress = shopAddress;
 		this.shopBio = shopBio;
 		this.shopDescription = shopDescription;
 		this.latitude = latitude;

--- a/cakk-domain/src/main/java/com/cakk/domain/repository/query/CakeShopQueryRepository.java
+++ b/cakk-domain/src/main/java/com/cakk/domain/repository/query/CakeShopQueryRepository.java
@@ -16,7 +16,9 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 
 import com.cakk.domain.dto.param.shop.CakeShopDetailParam;
+import com.cakk.domain.dto.param.shop.CakeShopInfoParam;
 import com.cakk.domain.dto.param.shop.CakeShopLinkParam;
+import com.cakk.domain.dto.param.shop.CakeShopOperationParam;
 import com.cakk.domain.dto.param.shop.CakeShopSimpleParam;
 
 @Repository
@@ -60,6 +62,27 @@ public class CakeShopQueryRepository {
 			.from(cakeShop)
 			.where(eqCakeShopId(cakeShopId))
 			.fetchOne();
+	}
+
+	public CakeShopInfoParam searchInfoById(Long cakeShopId) {
+		List<CakeShopInfoParam> results = queryFactory
+			.selectFrom(cakeShop)
+			.innerJoin(cakeShopOperation)
+			.on(cakeShop.eq(cakeShopOperation.cakeShop))
+			.where(eqCakeShopId(cakeShopId))
+			.transform(groupBy(cakeShop.id)
+				.list(Projections.constructor(CakeShopInfoParam.class,
+					cakeShop.shopAddress,
+					cakeShop.latitude,
+					cakeShop.longitude,
+					list(Projections.constructor(CakeShopOperationParam.class,
+						cakeShopOperation.operationDay,
+						cakeShopOperation.operationStartTime,
+						cakeShopOperation.operationEndTime)
+					)
+				)));
+
+		return results.isEmpty() ? null : results.get(0);
 	}
 
 	private BooleanExpression eqCakeShopId(Long cakeShopId) {

--- a/cakk-domain/src/main/java/com/cakk/domain/repository/reader/CakeShopReader.java
+++ b/cakk-domain/src/main/java/com/cakk/domain/repository/reader/CakeShopReader.java
@@ -8,6 +8,7 @@ import com.cakk.common.enums.ReturnCode;
 import com.cakk.common.exception.CakkException;
 import com.cakk.domain.annotation.Reader;
 import com.cakk.domain.dto.param.shop.CakeShopDetailParam;
+import com.cakk.domain.dto.param.shop.CakeShopInfoParam;
 import com.cakk.domain.dto.param.shop.CakeShopSimpleParam;
 import com.cakk.domain.entity.shop.CakeShop;
 import com.cakk.domain.entity.user.BusinessInformation;
@@ -39,6 +40,16 @@ public class CakeShopReader {
 
 	public CakeShopDetailParam searchDetailById(final Long cakeShopId) {
 		final CakeShopDetailParam response = cakeShopQueryRepository.searchDetailById(cakeShopId);
+
+		if (isNull(response)) {
+			throw new CakkException(ReturnCode.NOT_EXIST_CAKE_SHOP);
+		}
+
+		return response;
+	}
+
+	public CakeShopInfoParam searchInfoById(final Long cakeShopId) {
+		final CakeShopInfoParam response = cakeShopQueryRepository.searchInfoById(cakeShopId);
 
 		if (isNull(response)) {
 			throw new CakkException(ReturnCode.NOT_EXIST_CAKE_SHOP);


### PR DESCRIPTION
> ### Issue Number

#41

> ### Description

케이크 샵 상세 정보 조회 API를 개발했습니다. 특별한 로직 없이 조인하여 쿼리해왔습습니다.

```sql
select cs1_0.shop_id,
           cs1_0.shop_address,
           cs1_0.latitude,
           cs1_0.longitude,
            cso1_0.operation_day,
            cso1_0.start_time,
            cso1_0.end_time 
    from
        cake_shop cs1_0 
    join
        cake_shop_operation cso1_0 
            on cs1_0.shop_id=cso1_0.shop_id 
    where
        cs1_0.shop_id=1
```
> ### Core Code

```java

```

> ### etc
