### PR TITLE
Refactor: 위치 기반 케이크 샵 검색을 위한 리팩토링

### DIFF
--- a/cakk-api/build.gradle
+++ b/cakk-api/build.gradle
@@ -36,6 +36,9 @@ dependencies {
 
 	// slack 설정
 	implementation 'net.gpedro.integrations.slack:slack-webhook:1.4.0'
+
+	// Point
+	implementation 'org.locationtech.jts:jts-core:1.18.2'
 }
 
 tasks.named("bootJar") {

--- a/cakk-api/src/main/java/com/cakk/api/annotation/OperationDays.java
+++ b/cakk-api/src/main/java/com/cakk/api/annotation/OperationDays.java
@@ -1,4 +1,4 @@
-package com.cakk.api.validator;
+package com.cakk.api.annotation;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -7,6 +7,8 @@ import java.lang.annotation.Target;
 
 import jakarta.validation.Constraint;
 import jakarta.validation.Payload;
+
+import com.cakk.api.validator.OperationValidator;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)

--- a/cakk-api/src/main/java/com/cakk/api/annotation/OperationDays.java
+++ b/cakk-api/src/main/java/com/cakk/api/annotation/OperationDays.java
@@ -6,6 +6,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
 
 import com.cakk.api.annotation.validator.OperationValidator;
 
@@ -13,4 +14,10 @@ import com.cakk.api.annotation.validator.OperationValidator;
 @Target(ElementType.FIELD)
 @Constraint(validatedBy = OperationValidator.class)
 public @interface OperationDays {
+
+	String message() default "영업 일자 형식이 잘못됐습니다.";
+
+	Class<?>[] groups() default { };
+
+	Class<? extends Payload>[] payload() default { };
 }

--- a/cakk-api/src/main/java/com/cakk/api/dto/request/shop/CreateShopRequest.java
+++ b/cakk-api/src/main/java/com/cakk/api/dto/request/shop/CreateShopRequest.java
@@ -3,7 +3,7 @@ package com.cakk.api.dto.request.shop;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
-import com.cakk.api.validator.OperationDays;
+import com.cakk.api.annotation.OperationDays;
 
 public record CreateShopRequest(
 

--- a/cakk-api/src/main/java/com/cakk/api/dto/request/shop/CreateShopRequest.java
+++ b/cakk-api/src/main/java/com/cakk/api/dto/request/shop/CreateShopRequest.java
@@ -3,7 +3,7 @@ package com.cakk.api.dto.request.shop;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
-import com.cakk.api.annotation.OperationDays;
+import com.cakk.api.validator.OperationDays;
 
 public record CreateShopRequest(
 

--- a/cakk-api/src/main/java/com/cakk/api/mapper/PointMapper.java
+++ b/cakk-api/src/main/java/com/cakk/api/mapper/PointMapper.java
@@ -1,0 +1,19 @@
+package com.cakk.api.mapper;
+
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.PrecisionModel;
+
+public class PointMapper {
+
+	private static final int SPATIAL_REFERENCE_IDENTIFIER_NUMBER = 4326;
+
+	private static final GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(),
+		SPATIAL_REFERENCE_IDENTIFIER_NUMBER);
+
+	public static Point supplyPointBy(Double latitude, Double longitude) {
+		return geometryFactory.createPoint(new Coordinate(longitude, latitude));
+	}
+}
+

--- a/cakk-api/src/main/java/com/cakk/api/mapper/ShopMapper.java
+++ b/cakk-api/src/main/java/com/cakk/api/mapper/ShopMapper.java
@@ -23,12 +23,12 @@ import com.cakk.domain.mysql.entity.user.BusinessInformation;
 public class ShopMapper {
 
 	public static CakeShop supplyCakeShopBy(CreateShopRequest request) {
+
 		return CakeShop.builder()
 			.shopName(request.shopName())
 			.shopBio(request.shopBio())
 			.shopDescription(request.shopDescription())
-			.latitude(request.latitude())
-			.longitude(request.longitude())
+			.location(PointMapper.supplyPointBy(request.latitude(), request.longitude()))
 			.build();
 	}
 
@@ -87,10 +87,13 @@ public class ShopMapper {
 	}
 
 	public static CakeShopInfoResponse supplyCakeShopInfoResponseBy(CakeShopInfoParam param) {
+		Double longitude = param.point().getX();
+		Double latitude = param.point().getY();
+
 		return new CakeShopInfoResponse(
 			param.shopAddress(),
-			param.latitude(),
-			param.longitude(),
+			latitude,
+			longitude,
 			param.shopOperationDays()
 		);
 	}

--- a/cakk-api/src/main/java/com/cakk/api/service/slack/SlackService.java
+++ b/cakk-api/src/main/java/com/cakk/api/service/slack/SlackService.java
@@ -87,8 +87,8 @@ public class SlackService {
 			new SlackField().setTitle("요청자 사업자등록증 이미지").setValue(certificationEvent.businessRegistrationImageUrl()),
 			new SlackField().setTitle("요청 사항").setValue(certificationEvent.message()),
 			new SlackField().setTitle("가게 이름").setValue(certificationEvent.shopName()),
-			new SlackField().setTitle("가게 위치 위도").setValue(String.valueOf(certificationEvent.shopLatitude())),
-			new SlackField().setTitle("가게 위치 경도").setValue(String.valueOf(certificationEvent.shopLongitude()))
+			new SlackField().setTitle("가게 위치 위도").setValue(String.valueOf(certificationEvent.location().getY())),
+			new SlackField().setTitle("가게 위치 경도").setValue(String.valueOf(certificationEvent.location().getX()))
 		));
 
 		SlackMessage slackMessage = new SlackMessage();

--- a/cakk-api/src/main/java/com/cakk/api/validator/OperationDays.java
+++ b/cakk-api/src/main/java/com/cakk/api/validator/OperationDays.java
@@ -1,4 +1,4 @@
-package com.cakk.api.annotation;
+package com.cakk.api.validator;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -7,8 +7,6 @@ import java.lang.annotation.Target;
 
 import jakarta.validation.Constraint;
 import jakarta.validation.Payload;
-
-import com.cakk.api.annotation.validator.OperationValidator;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)

--- a/cakk-api/src/main/java/com/cakk/api/validator/OperationValidator.java
+++ b/cakk-api/src/main/java/com/cakk/api/validator/OperationValidator.java
@@ -3,6 +3,7 @@ package com.cakk.api.validator;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 
+import com.cakk.api.annotation.OperationDays;
 import com.cakk.api.dto.request.shop.OperationDayRequest;
 
 public class OperationValidator implements ConstraintValidator<OperationDays, OperationDayRequest> {

--- a/cakk-api/src/main/java/com/cakk/api/validator/OperationValidator.java
+++ b/cakk-api/src/main/java/com/cakk/api/validator/OperationValidator.java
@@ -1,9 +1,9 @@
-package com.cakk.api.annotation.validator;
+package com.cakk.api.validator;
 
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 
-import com.cakk.api.annotation.OperationDays;
+import com.cakk.api.validator.OperationDays;
 import com.cakk.api.dto.request.shop.OperationDayRequest;
 
 public class OperationValidator implements ConstraintValidator<OperationDays, OperationDayRequest> {

--- a/cakk-api/src/main/java/com/cakk/api/validator/OperationValidator.java
+++ b/cakk-api/src/main/java/com/cakk/api/validator/OperationValidator.java
@@ -3,7 +3,6 @@ package com.cakk.api.validator;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 
-import com.cakk.api.validator.OperationDays;
 import com.cakk.api.dto.request.shop.OperationDayRequest;
 
 public class OperationValidator implements ConstraintValidator<OperationDays, OperationDayRequest> {

--- a/cakk-api/src/main/resources/application.yml
+++ b/cakk-api/src/main/resources/application.yml
@@ -14,7 +14,7 @@ spring:
       ddl-auto: update
     properties:
       hibernate:
-        dialect: org.hibernate.dialect.MySQLDialect
+        dialect: org.hibernate.dialect.MySQL8Dialect
         format_sql: true
         show_sql: false
   flyway:

--- a/cakk-api/src/test/java/com/cakk/api/common/base/IntegrationTest.java
+++ b/cakk-api/src/test/java/com/cakk/api/common/base/IntegrationTest.java
@@ -14,6 +14,7 @@ import com.navercorp.fixturemonkey.FixtureMonkey;
 import com.navercorp.fixturemonkey.api.introspector.BuilderArbitraryIntrospector;
 import com.navercorp.fixturemonkey.api.introspector.ConstructorPropertiesArbitraryIntrospector;
 import com.navercorp.fixturemonkey.api.introspector.FieldReflectionArbitraryIntrospector;
+import com.navercorp.fixturemonkey.jakarta.validation.plugin.JakartaValidationPlugin;
 
 @ExtendWith(SpringExtension.class)
 @ActiveProfiles("test")
@@ -36,18 +37,21 @@ public abstract class IntegrationTest {
 
 	protected final FixtureMonkey getConstructorMonkey() {
 		return FixtureMonkey.builder()
+			.plugin(new JakartaValidationPlugin())
 			.objectIntrospector(ConstructorPropertiesArbitraryIntrospector.INSTANCE)
 			.build();
 	}
 
 	protected final FixtureMonkey getReflectionMonkey() {
 		return FixtureMonkey.builder()
+			.plugin(new JakartaValidationPlugin())
 			.objectIntrospector(FieldReflectionArbitraryIntrospector.INSTANCE)
 			.build();
 	}
 
 	protected final FixtureMonkey getBuilderMonkey() {
 		return FixtureMonkey.builder()
+			.plugin(new JakartaValidationPlugin())
 			.objectIntrospector(BuilderArbitraryIntrospector.INSTANCE)
 			.build();
 	}

--- a/cakk-api/src/test/java/com/cakk/api/common/base/ServiceTest.java
+++ b/cakk-api/src/test/java/com/cakk/api/common/base/ServiceTest.java
@@ -1,6 +1,10 @@
 package com.cakk.api.common.base;
 
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.PrecisionModel;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
@@ -17,6 +21,13 @@ import com.cakk.domain.mysql.config.JpaConfig;
 @ActiveProfiles("test")
 @ExtendWith(MockitoExtension.class)
 public abstract class ServiceTest {
+
+	private static final int SPATIAL_REFERENCE_IDENTIFIER_NUMBER = 4326;
+
+	private static final GeometryFactory geometryFactory = new GeometryFactory(
+		new PrecisionModel(),
+		SPATIAL_REFERENCE_IDENTIFIER_NUMBER
+	);
 
 	protected final FixtureMonkey getConstructorMonkey() {
 		return FixtureMonkey.builder()
@@ -37,5 +48,9 @@ public abstract class ServiceTest {
 			.plugin(new JakartaValidationPlugin())
 			.objectIntrospector(BuilderArbitraryIntrospector.INSTANCE)
 			.build();
+	}
+
+	public static Point supplyPointBy(Double latitude, Double longitude) {
+		return geometryFactory.createPoint(new Coordinate(longitude, latitude));
 	}
 }

--- a/cakk-api/src/test/java/com/cakk/api/common/base/ServiceTest.java
+++ b/cakk-api/src/test/java/com/cakk/api/common/base/ServiceTest.java
@@ -9,6 +9,7 @@ import com.navercorp.fixturemonkey.FixtureMonkey;
 import com.navercorp.fixturemonkey.api.introspector.BuilderArbitraryIntrospector;
 import com.navercorp.fixturemonkey.api.introspector.ConstructorPropertiesArbitraryIntrospector;
 import com.navercorp.fixturemonkey.api.introspector.FieldReflectionArbitraryIntrospector;
+import com.navercorp.fixturemonkey.jakarta.validation.plugin.JakartaValidationPlugin;
 
 import com.cakk.domain.mysql.config.JpaConfig;
 
@@ -19,18 +20,21 @@ public abstract class ServiceTest {
 
 	protected final FixtureMonkey getConstructorMonkey() {
 		return FixtureMonkey.builder()
+			.plugin(new JakartaValidationPlugin())
 			.objectIntrospector(ConstructorPropertiesArbitraryIntrospector.INSTANCE)
 			.build();
 	}
 
 	protected final FixtureMonkey getReflectionMonkey() {
 		return FixtureMonkey.builder()
+			.plugin(new JakartaValidationPlugin())
 			.objectIntrospector(FieldReflectionArbitraryIntrospector.INSTANCE)
 			.build();
 	}
 
 	protected final FixtureMonkey getBuilderMonkey() {
 		return FixtureMonkey.builder()
+			.plugin(new JakartaValidationPlugin())
 			.objectIntrospector(BuilderArbitraryIntrospector.INSTANCE)
 			.build();
 	}

--- a/cakk-api/src/test/java/com/cakk/api/integration/shop/ShopIntegrationTest.java
+++ b/cakk-api/src/test/java/com/cakk/api/integration/shop/ShopIntegrationTest.java
@@ -245,9 +245,12 @@ public class ShopIntegrationTest extends IntegrationTest {
 		assertEquals(ReturnCode.SUCCESS.getMessage(), response.getReturnMessage());
 
 		final CakeShop cakeShop = cakeShopReader.findById(cakeShopId);
+		Double longitude = cakeShop.getLocation().getX();
+		Double latitude = cakeShop.getLocation().getY();
+
 		assertEquals(cakeShop.getShopAddress(), data.shopAddress());
-		assertEquals(cakeShop.getLatitude(), data.latitude());
-		assertEquals(cakeShop.getLongitude(), data.longitude());
+		assertEquals(latitude, data.latitude());
+		assertEquals(longitude, data.longitude());
 
 		List<CakeShopOperationParam> cakeShopOperations = cakeShopOperationReader.findAllByCakeShopId(cakeShopId).stream()
 			.map((it) -> new CakeShopOperationParam(it.getOperationDay(), it.getOperationStartTime(), it.getOperationEndTime()))

--- a/cakk-api/src/test/resources/sql/insert-cake-shop.sql
+++ b/cakk-api/src/test/resources/sql/insert-cake-shop.sql
@@ -1,8 +1,12 @@
-insert into cake_shop (shop_id, thumbnail_url, shop_name, shop_address, shop_bio, shop_description, latitude, longitude, like_count, linked_flag,
+SET @g1 = 'Point(37.197734 127.098190)';
+SET @g2 = 'Point(37.201623 127.091568)';
+SET @g3 = 'Point(37.209769 127.100107)';
+
+insert into cake_shop (shop_id, thumbnail_url, shop_name, shop_address, shop_bio, shop_description, location, like_count, linked_flag,
                        created_at, updated_at)
-values (1, 'thumbnail_url1', '케이크 맛집1', '케이크 맛집입니다.', '서울시 강남구 어쩌고로1', '케이크 맛집입니다.', 37.123456, 127.123456, 0, false, now(), now()),
-       (2, 'thumbnail_url2', '케이크 맛집2', '케이크 맛집입니다.', '서울시 강남구 어쩌고로2', '케이크 맛집입니다.', 38.123456, 128.123456, 0, false, now(), now()),
-       (3, 'thumbnail_url3', '케이크 맛집3', '케이크 맛집입니다.', '서울시 강남구 어쩌고로3', '케이크 맛집입니다.', 39.123456, 129.123456, 0, false, now(), now());
+values (1, 'thumbnail_url1', '케이크 맛집1', '케이크 맛집입니다.', '서울시 강남구 어쩌고로1', '케이크 맛집입니다.', ST_GeomFromText(@g1, 4326), 0, false, now(), now()),
+       (2, 'thumbnail_url2', '케이크 맛집2', '케이크 맛집입니다.', '서울시 강남구 어쩌고로2', '케이크 맛집입니다.', ST_GeomFromText(@g2, 4326), 0, false, now(), now()),
+       (3, 'thumbnail_url3', '케이크 맛집3', '케이크 맛집입니다.', '서울시 강남구 어쩌고로3', '케이크 맛집입니다.', ST_GeomFromText(@g3, 4326), 0, false, now(), now());
 
 insert into cake_shop_operation (operation_id, shop_id, operation_day, start_time, end_time, created_at, updated_at)
 values (1, 1, 0, '10:00:00', '22:00:00', now(), now()),

--- a/cakk-api/src/test/resources/sql/insert-cake.sql
+++ b/cakk-api/src/test/resources/sql/insert-cake.sql
@@ -1,7 +1,10 @@
-insert into cake_shop (shop_id, thumbnail_url, shop_name, shop_bio, shop_description, latitude, longitude, like_count, linked_flag,
+SET @g1 = 'Point(37.197734 127.098190)';
+SET @g2 = 'Point(37.201623 127.091568)';
+
+insert into cake_shop (shop_id, thumbnail_url, shop_name, shop_bio, shop_description, location, like_count, linked_flag,
                        created_at, updated_at)
-values (1, 'thumbnail_url', '케이크 맛집', '케이크 맛집입니다.', '케이크 맛집입니다.', 37.123456, 127.123456, 0, false, now(), now()),
-       (2, 'thumbnail_url2', '케이크 맛집2', '케이크 맛집입니다.', '케이크 맛집입니다.', 38.123456, 128.123456, 0, false, now(), now());
+values (1, 'thumbnail_url', '케이크 맛집', '케이크 맛집입니다.', '케이크 맛집입니다.', ST_GeomFromText(@g1, 4326), 0, false, now(), now()),
+       (2, 'thumbnail_url2', '케이크 맛집2', '케이크 맛집입니다.', '케이크 맛집입니다.', ST_GeomFromText(@g1, 4326), 0, false, now(), now());
 
 insert into cake (cake_id, shop_id, cake_image_url, like_count, created_at, updated_at)
 values (1, 1, 'cake_image_url1', 0, now(), now()),

--- a/cakk-domain/mysql/build.gradle
+++ b/cakk-domain/mysql/build.gradle
@@ -18,6 +18,8 @@ dependencies {
     annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+	implementation 'org.hibernate.orm:hibernate-spatial:6.4.4.Final'
+	implementation 'com.querydsl:querydsl-spatial'
 
     // database
     runtimeOnly 'com.mysql:mysql-connector-j:8.2.0'

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/dto/param/shop/CakeShopInfoParam.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/dto/param/shop/CakeShopInfoParam.java
@@ -2,10 +2,11 @@ package com.cakk.domain.mysql.dto.param.shop;
 
 import java.util.List;
 
+import org.locationtech.jts.geom.Point;
+
 public record CakeShopInfoParam(
 	String shopAddress,
-	Double latitude,
-	Double longitude,
+	Point point,
 	List<CakeShopOperationParam> shopOperationDays
 ) {
 }

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/entity/cake/CakeTag.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/entity/cake/CakeTag.java
@@ -33,11 +33,11 @@ public class CakeTag extends AuditCreatedEntity {
 	private Cake cake;
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "user_id", referencedColumnName = "user_id", nullable = false)
-	private User user;
+	@JoinColumn(name = "tag_id", referencedColumnName = "tag_id", nullable = false)
+	private Tag tag;
 
-	public CakeTag(Cake cake, User user) {
+	public CakeTag(Cake cake, Tag tag) {
 		this.cake = cake;
-		this.user = user;
+		this.tag = tag;
 	}
 }

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/entity/shop/CakeShop.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/entity/shop/CakeShop.java
@@ -10,6 +10,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
 import org.hibernate.annotations.ColumnDefault;
+import org.locationtech.jts.geom.Point;
 
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -44,11 +45,8 @@ public class CakeShop extends AuditEntity {
 	@Column(name = "shop_description", length = 500)
 	private String shopDescription;
 
-	@Column(name = "latitude", nullable = false, columnDefinition = "DECIMAL(18,10)")
-	private Double latitude;
-
-	@Column(name = "longitude", nullable = false, columnDefinition = "DECIMAL(18,10)")
-	private Double longitude;
+	@Column(name = "location", nullable = false, columnDefinition = "POINT SRID 4326")
+	private Point location;
 
 	@ColumnDefault("0")
 	@Column(name = "like_count", nullable = false, columnDefinition = "MEDIUMINT")
@@ -69,16 +67,14 @@ public class CakeShop extends AuditEntity {
 		String shopAddress,
 		String shopBio,
 		String shopDescription,
-		Double latitude,
-		Double longitude
+		Point location
 	) {
 		this.shopName = shopName;
 		this.thumbnailUrl = thumbnailUrl;
 		this.shopAddress = shopAddress;
 		this.shopBio = shopBio;
 		this.shopDescription = shopDescription;
-		this.latitude = latitude;
-		this.longitude = longitude;
+		this.location = location;
 		this.likeCount = 0;
 		this.linkedFlag = false;
 	}

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/entity/shop/CakeShop.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/entity/shop/CakeShop.java
@@ -13,6 +13,7 @@ import org.hibernate.annotations.ColumnDefault;
 import org.locationtech.jts.geom.Point;
 
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -20,6 +21,7 @@ import lombok.NoArgsConstructor;
 import com.cakk.domain.mysql.entity.audit.AuditEntity;
 
 @Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name = "cake_shop")

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/entity/user/BusinessInformation.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/entity/user/BusinessInformation.java
@@ -11,6 +11,7 @@ import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -22,6 +23,7 @@ import com.cakk.domain.mysql.event.EventMapper;
 import com.cakk.domain.mysql.event.shop.CertificationEvent;
 
 @Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name = "business_information")

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/event/EventMapper.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/event/EventMapper.java
@@ -18,8 +18,7 @@ public class EventMapper {
 			.userId(param.user().getId())
 			.userEmail(param.user().getEmail())
 			.shopName(cakeShop.getShopName())
-			.shopLatitude(cakeShop.getLatitude())
-			.shopLongitude(cakeShop.getLongitude())
+			.location(cakeShop.getLocation())
 			.build();
 	}
 

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/event/shop/CertificationEvent.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/event/shop/CertificationEvent.java
@@ -1,5 +1,7 @@
 package com.cakk.domain.mysql.event.shop;
 
+import org.locationtech.jts.geom.Point;
+
 import lombok.Builder;
 
 @Builder
@@ -11,7 +13,6 @@ public record CertificationEvent(
 	Long userId,
 	String userEmail,
 	String shopName,
-	Double shopLatitude,
-	Double shopLongitude
+	Point location
 ) {
 }

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/query/CakeShopQueryRepository.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/query/CakeShopQueryRepository.java
@@ -73,8 +73,7 @@ public class CakeShopQueryRepository {
 			.transform(groupBy(cakeShop.id)
 				.list(Projections.constructor(CakeShopInfoParam.class,
 					cakeShop.shopAddress,
-					cakeShop.latitude,
-					cakeShop.longitude,
+					cakeShop.location,
 					list(Projections.constructor(CakeShopOperationParam.class,
 						cakeShopOperation.operationDay,
 						cakeShopOperation.operationStartTime,

--- a/cakk-domain/mysql/src/test/java/com/cakk/domain/base/DomainTest.java
+++ b/cakk-domain/mysql/src/test/java/com/cakk/domain/base/DomainTest.java
@@ -1,20 +1,47 @@
 package com.cakk.domain.base;
 
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.PrecisionModel;
+
 import com.navercorp.fixturemonkey.FixtureMonkey;
 import com.navercorp.fixturemonkey.api.introspector.BuilderArbitraryIntrospector;
+import com.navercorp.fixturemonkey.api.introspector.ConstructorPropertiesArbitraryIntrospector;
 import com.navercorp.fixturemonkey.api.introspector.FieldReflectionArbitraryIntrospector;
+import com.navercorp.fixturemonkey.jakarta.validation.plugin.JakartaValidationPlugin;
 
 public abstract class DomainTest {
 
+	private static final int SPATIAL_REFERENCE_IDENTIFIER_NUMBER = 4326;
+
+	private static final GeometryFactory geometryFactory = new GeometryFactory(
+		new PrecisionModel(),
+		SPATIAL_REFERENCE_IDENTIFIER_NUMBER
+	);
+
 	protected final FixtureMonkey getReflectionMonkey() {
 		return FixtureMonkey.builder()
+			.plugin(new JakartaValidationPlugin())
 			.objectIntrospector(FieldReflectionArbitraryIntrospector.INSTANCE)
+			.build();
+	}
+
+	protected final FixtureMonkey getConstructorMonkey() {
+		return FixtureMonkey.builder()
+			.plugin(new JakartaValidationPlugin())
+			.objectIntrospector(ConstructorPropertiesArbitraryIntrospector.INSTANCE)
 			.build();
 	}
 
 	protected final FixtureMonkey getBuilderMonkey() {
 		return FixtureMonkey.builder()
+			.plugin(new JakartaValidationPlugin())
 			.objectIntrospector(BuilderArbitraryIntrospector.INSTANCE)
 			.build();
+	}
+
+	public static Point supplyPointBy(Double latitude, Double longitude) {
+		return geometryFactory.createPoint(new Coordinate(longitude, latitude));
 	}
 }

--- a/cakk-domain/mysql/src/test/java/com/cakk/domain/entity/user/BusinessInformationTest.java
+++ b/cakk-domain/mysql/src/test/java/com/cakk/domain/entity/user/BusinessInformationTest.java
@@ -17,13 +17,14 @@ import com.cakk.domain.mysql.event.shop.CertificationEvent;
 class BusinessInformationTest extends DomainTest {
 
 	private CakeShop getCakeShopFixture() {
-		return getReflectionMonkey().giveMeBuilder(CakeShop.class)
+		return getConstructorMonkey().giveMeBuilder(CakeShop.class)
 			.set("shopName", Arbitraries.strings().withCharRange('a', 'z').ofMaxLength(30))
+			.set("location", supplyPointBy(Arbitraries.doubles().sample(), Arbitraries.doubles().sample()))
 			.sample();
 	}
 
 	private BusinessInformation getBusinessInformationFixture() {
-		return getReflectionMonkey().giveMeBuilder(BusinessInformation.class)
+		return getConstructorMonkey().giveMeBuilder(BusinessInformation.class)
 			.set("businessNumber", Arbitraries.strings().withCharRange('a', 'z').ofMaxLength(20))
 			.setNull("cakeShop")
 			.setNull("user")
@@ -31,7 +32,7 @@ class BusinessInformationTest extends DomainTest {
 	}
 
 	private BusinessInformation getBusinessInformationFixtureWithCakeShop() {
-		return getReflectionMonkey().giveMeBuilder(BusinessInformation.class)
+		return getConstructorMonkey().giveMeBuilder(BusinessInformation.class)
 			.set("businessNumber", Arbitraries.strings().withCharRange('a', 'z').ofMaxLength(20))
 			.set("cakeShop", getCakeShopFixture())
 			.setNull("user")
@@ -49,6 +50,16 @@ class BusinessInformationTest extends DomainTest {
 			.set("user", user)
 			.set("message", Arbitraries.strings().withCharRange('a', 'z').ofMaxLength(20))
 			.sample();
+	}
+
+	@Test
+	void test() {
+		CakeShop cakeShop = getCakeShopFixture();
+
+		System.out.println(cakeShop.getShopName());
+		System.out.println(cakeShop.getShopAddress());
+		System.out.println(cakeShop.getShopBio());
+		System.out.println(cakeShop.getLocation());
 	}
 
 	@Test

--- a/cakk-domain/mysql/src/test/java/com/cakk/domain/entity/user/BusinessInformationTest.java
+++ b/cakk-domain/mysql/src/test/java/com/cakk/domain/entity/user/BusinessInformationTest.java
@@ -53,16 +53,6 @@ class BusinessInformationTest extends DomainTest {
 	}
 
 	@Test
-	void test() {
-		CakeShop cakeShop = getCakeShopFixture();
-
-		System.out.println(cakeShop.getShopName());
-		System.out.println(cakeShop.getShopAddress());
-		System.out.println(cakeShop.getShopBio());
-		System.out.println(cakeShop.getLocation());
-	}
-
-	@Test
 	void 케이크샵이_존재한다면_가게_정보와_함께_서비스에_인증요청을_한다() {
 		//given
 		BusinessInformation businessInformation = getBusinessInformationFixtureWithCakeShop();


### PR DESCRIPTION
> ### Issue Number

#48 

> ### Description

- CakeTag 연관 관계를 수정했습니다 https://github.com/CAKK-DEV/cakk-server/commit/291ae649c3f78ccc02b5d8548de3e30476960717  CakeTag가 Cake와 Tag 관계를 가지고 있어야 하는데 User와 관계를 가지고 있었습니다
- MySQL Version 명시 Dialect를 진행했습니다
- MySQL 8.0 버전 이후부터 사용할 수 있는 위치 기반 함수와 QueryDSL을 위해 의존성을 추가했습니다 WGS84(GPS) 기준의 위도 경도
- 경도(longitude), 위도(latitude) 를 기반으로 Point 객체로 추상화하여 구 형태의 객체 인스턴스로 활용할 수 있도록 리팩토링 했습니다
- SQL Script에서 Point 객체로 지정하여 Insert되도록 수정했습니다


MySQL에서 지원하는  `Spatial Index(공간 인덱스)` R-Tree 인덱스 알고리즘을 이용해 2차원의 데이터를 인덱싱하고 검색할 수 있습니다
내부 메커니즘은 B-Tree와 흡사합니다

이와 관련하여 Geometry(기하학적 도형) 정보를 관리할 수 있는 데이터 타입을 지원하고 있는데,
POINT, LINE, POLYGON 등 여러 TYPE중 가장 간단한 POINT(https://dev.mysql.com/doc/refman/8.0/en/gis-class-point.html) 를 선택했습니다
![GIS](https://github.com/CAKK-DEV/cakk-server/assets/86272688/d199caed-c351-4da5-9e9d-45c802b7f4ad)

R-Tree 알고리즘에서는 MBR(Minimum Bounding Rectangle) 즉, 해당 도형을 감싸는 최소 크기의 사각형을 기반으로 동작합니다
고도화 함에 따라 다른 TYPE을 선택할 수 있겠지만 쉽고 빠르게 적용하기 위해 POINT를 선택한 이유가 될 수 있습니다

즉, POINT를 중심으로 최소 크기의 사각형이 생긴다고 바라볼 수 있습니다
예를 들어, 해당 POINT를 중심으로 5km이내에 POINT를 검색한다고 할 때, 반지름 5km, 지름 10km의 원을 그리게 됩니다. 
이 후, 원을 기반으로 사각형을 그리면 최소 크기의 사각형을 만들 수 있습니다

이 사각형 내에 있는 POINT를 탐색할 수 있습니다
FUNCTION들
https://dev.mysql.com/doc/refman/8.0/en/spatial-function-reference.html
> ### Core Code
기존에는 테스트 Fixture를 생성할 때, Reflection 방법으로 CakeShop과 BusinessInformation을 생성하였고, 임의로(Arbitrary) 값을 집어 넣을 수 있었습니다
하지만, Point 객체에서 Reflection 에러가 발생했고, Duplication 에러가 발생했는데 원인을 해결하지 못했습니다

따라서, 다른 방법을 찾던 도중에 생성자 기반의 테스트 객체 방법을 선택하였고
모든 필드에 대해 임의 값을 집어 넣어주기 위한 @AllArgsConstructor 애노테이션을 선언하였습니다
그 이유는 생성자 기반 방식 Fixture는 Entity 내에 생성자가 존재해야만 활용할 수 있습니다
AllArgsConstructor 생성자가 존재하지 않으면, 모든 필드들에 대해 Null값이 들어간 Instance를 반환합니다
```java
@AllArgsConstructor(access = AccessLevel.PRIVATE)
```
PRIVATE 접근 제한을 두어, 함부로 생성될 수 없게 제한했습니다

> ### etc
