### PR TITLE
Feature: 토큰 재발급 로직 작성

### DIFF
--- a/cakk-api/src/main/java/com/cakk/api/annotation/RefreshToken.java
+++ b/cakk-api/src/main/java/com/cakk/api/annotation/RefreshToken.java
@@ -1,0 +1,11 @@
+package com.cakk.api.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RefreshToken {
+}

--- a/cakk-api/src/main/java/com/cakk/api/config/WebMvcConfig.java
+++ b/cakk-api/src/main/java/com/cakk/api/config/WebMvcConfig.java
@@ -7,6 +7,7 @@ import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import com.cakk.api.resolver.AuthorizedUserResolver;
+import com.cakk.api.resolver.RefreshTokenResolver;
 
 @Configuration
 public class WebMvcConfig implements WebMvcConfigurer {
@@ -14,5 +15,6 @@ public class WebMvcConfig implements WebMvcConfigurer {
 	@Override
 	public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
 		resolvers.add(new AuthorizedUserResolver());
+		resolvers.add(new RefreshTokenResolver());
 	}
 }

--- a/cakk-api/src/main/java/com/cakk/api/controller/user/SignController.java
+++ b/cakk-api/src/main/java/com/cakk/api/controller/user/SignController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
 
+import com.cakk.api.annotation.RefreshToken;
 import com.cakk.api.dto.request.user.UserSignInRequest;
 import com.cakk.api.dto.request.user.UserSignUpRequest;
 import com.cakk.api.dto.response.user.JwtResponse;
@@ -32,5 +33,14 @@ public class SignController {
 		@Valid @RequestBody UserSignInRequest request
 	) {
 		return ApiResponse.success(userService.signIn(request));
+	}
+
+	@PostMapping("/recreate-token")
+	public ApiResponse<JwtResponse> recreate(
+		@RefreshToken String refreshToken
+	) {
+		final JwtResponse response = userService.recreateToken(refreshToken);
+
+		return ApiResponse.success(response);
 	}
 }

--- a/cakk-api/src/main/java/com/cakk/api/provider/jwt/JwtProvider.java
+++ b/cakk-api/src/main/java/com/cakk/api/provider/jwt/JwtProvider.java
@@ -65,6 +65,7 @@ public class JwtProvider {
 				.signWith(key, SignatureAlgorithm.HS512)
 				.compact();
 			final String refreshToken = Jwts.builder()
+				.claim(userKey, user)
 				.setExpiration(new Date(System.currentTimeMillis() + refreshTokenExpiredSecond))
 				.signWith(key, SignatureAlgorithm.HS512)
 				.compact();

--- a/cakk-api/src/main/java/com/cakk/api/provider/jwt/JwtProvider.java
+++ b/cakk-api/src/main/java/com/cakk/api/provider/jwt/JwtProvider.java
@@ -79,17 +79,25 @@ public class JwtProvider {
 		}
 	}
 
-	public Authentication getAuthentication(String accessToken) {
-		final Claims claims = parseClaims(accessToken);
+	public Authentication getAuthentication(String token) {
+		final User user = getUser(token);
+		final OAuthUserDetails userDetails = new OAuthUserDetails(user);
+
+		return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+	}
+
+	public User getUser(String token) {
+		final Claims claims = parseClaims(token);
 
 		if (isNull(claims.get(userKey))) {
 			throw new CakkException(EMPTY_AUTH_JWT);
 		}
 
-		final User user = new ObjectMapper().convertValue(claims.get(userKey), User.class);
-		OAuthUserDetails userDetails = new OAuthUserDetails(user);
+		return new ObjectMapper().convertValue(claims.get(userKey), User.class);
+	}
 
-		return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+	public long getRefreshTokenExpiredSecond() {
+		return this.refreshTokenExpiredSecond;
 	}
 
 	public Claims parseClaims(String token) {

--- a/cakk-api/src/main/java/com/cakk/api/resolver/RefreshTokenResolver.java
+++ b/cakk-api/src/main/java/com/cakk/api/resolver/RefreshTokenResolver.java
@@ -1,0 +1,38 @@
+package com.cakk.api.resolver;
+
+import static org.springframework.util.StringUtils.*;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import com.cakk.api.annotation.RefreshToken;
+import com.cakk.common.enums.ReturnCode;
+import com.cakk.common.exception.CakkException;
+
+public class RefreshTokenResolver implements HandlerMethodArgumentResolver {
+
+	@Override
+	public boolean supportsParameter(MethodParameter parameter) {
+		return parameter.hasParameterAnnotation(RefreshToken.class)
+			&& String.class.isAssignableFrom(parameter.getParameterType());
+	}
+
+	@Override
+	public String resolveArgument(
+		MethodParameter parameter,
+		ModelAndViewContainer mavContainer,
+		NativeWebRequest webRequest,
+		WebDataBinderFactory binderFactory
+	) {
+		String refreshToken = webRequest.getHeader("Refresh");
+
+		if (hasLength(refreshToken)) {
+			throw new CakkException(ReturnCode.EMPTY_REFRESH);
+		}
+
+		return refreshToken;
+	}
+}

--- a/cakk-api/src/main/java/com/cakk/api/resolver/RefreshTokenResolver.java
+++ b/cakk-api/src/main/java/com/cakk/api/resolver/RefreshTokenResolver.java
@@ -29,7 +29,7 @@ public class RefreshTokenResolver implements HandlerMethodArgumentResolver {
 	) {
 		String refreshToken = webRequest.getHeader("Refresh");
 
-		if (hasLength(refreshToken)) {
+		if (!hasLength(refreshToken)) {
 			throw new CakkException(ReturnCode.EMPTY_REFRESH);
 		}
 

--- a/cakk-api/src/main/java/com/cakk/api/service/user/UserService.java
+++ b/cakk-api/src/main/java/com/cakk/api/service/user/UserService.java
@@ -49,7 +49,9 @@ public class UserService {
 
 	@Transactional(readOnly = true)
 	public JwtResponse recreateToken(final String refreshToken) {
-		if (tokenRedisRepository.isBlackListToken(refreshToken)) {
+		final boolean isBlackList = tokenRedisRepository.isBlackListToken(refreshToken);
+
+		if (isBlackList) {
 			throw new CakkException(ReturnCode.BLACK_LIST_TOKEN);
 		}
 

--- a/cakk-api/src/main/java/com/cakk/api/service/user/UserService.java
+++ b/cakk-api/src/main/java/com/cakk/api/service/user/UserService.java
@@ -1,5 +1,7 @@
 package com.cakk.api.service.user;
 
+import java.util.concurrent.TimeUnit;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -11,9 +13,12 @@ import com.cakk.api.dto.response.user.JwtResponse;
 import com.cakk.api.factory.OidcProviderFactory;
 import com.cakk.api.mapper.UserMapper;
 import com.cakk.api.provider.jwt.JwtProvider;
+import com.cakk.common.enums.ReturnCode;
+import com.cakk.common.exception.CakkException;
 import com.cakk.domain.mysql.entity.user.User;
 import com.cakk.domain.mysql.repository.reader.UserReader;
 import com.cakk.domain.mysql.repository.writer.UserWriter;
+import com.cakk.domain.redis.repository.impl.TokenRedisRepository;
 
 @Service
 @RequiredArgsConstructor
@@ -24,6 +29,7 @@ public class UserService {
 
 	private final UserReader userReader;
 	private final UserWriter userWriter;
+	private final TokenRedisRepository tokenRedisRepository;
 
 	@Transactional
 	public JwtResponse signUp(UserSignUpRequest dto) {
@@ -37,6 +43,20 @@ public class UserService {
 	public JwtResponse signIn(UserSignInRequest dto) {
 		final String providerId = oidcProviderFactory.getProviderId(dto.provider(), dto.idToken());
 		final User user = userReader.findByProviderId(providerId);
+
+		return JwtResponse.from(jwtProvider.generateToken(user));
+	}
+
+	@Transactional(readOnly = true)
+	public JwtResponse recreateToken(final String refreshToken) {
+		if (tokenRedisRepository.isBlackListToken(refreshToken)) {
+			throw new CakkException(ReturnCode.BLACK_LIST_TOKEN);
+		}
+
+		final User user = jwtProvider.getUser(refreshToken);
+		final long expiredSecond = jwtProvider.getRefreshTokenExpiredSecond();
+
+		tokenRedisRepository.save(refreshToken, "refresh", expiredSecond, TimeUnit.MILLISECONDS);
 
 		return JwtResponse.from(jwtProvider.generateToken(user));
 	}

--- a/cakk-api/src/main/java/com/cakk/api/service/user/UserService.java
+++ b/cakk-api/src/main/java/com/cakk/api/service/user/UserService.java
@@ -1,7 +1,5 @@
 package com.cakk.api.service.user;
 
-import java.util.concurrent.TimeUnit;
-
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -58,7 +56,7 @@ public class UserService {
 		final User user = jwtProvider.getUser(refreshToken);
 		final long expiredSecond = jwtProvider.getRefreshTokenExpiredSecond();
 
-		tokenRedisRepository.save(refreshToken, "refresh", expiredSecond, TimeUnit.MILLISECONDS);
+		tokenRedisRepository.registerBlackList(refreshToken, expiredSecond);
 
 		return JwtResponse.from(jwtProvider.generateToken(user));
 	}

--- a/cakk-api/src/main/resources/application.yml
+++ b/cakk-api/src/main/resources/application.yml
@@ -14,7 +14,7 @@ spring:
       ddl-auto: update
     properties:
       hibernate:
-        dialect: org.hibernate.dialect.MySQL8Dialect
+        dialect: org.hibernate.dialect.MySQLDialect
         format_sql: true
         show_sql: false
   flyway:

--- a/cakk-api/src/test/java/com/cakk/api/common/container/RedisTestContainer.java
+++ b/cakk-api/src/test/java/com/cakk/api/common/container/RedisTestContainer.java
@@ -1,21 +1,27 @@
 package com.cakk.api.common.container;
 
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ActiveProfiles;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
 
-@Testcontainers
+@ActiveProfiles("test")
+@Configuration
 public class RedisTestContainer {
 
 	private static final String REDIS_IMAGE = "redis:7.2-alpine";
 	private static final int REDIS_PORT = 6379;
 
 	@Container
-	public static final GenericContainer REDIS_CONTAINER = new GenericContainer(REDIS_IMAGE)
+	public static final GenericContainer<?> REDIS_CONTAINER = new GenericContainer<>(DockerImageName.parse(REDIS_IMAGE))
 		.withExposedPorts(REDIS_PORT)
 		.withReuse(true);
 
 	static {
 		REDIS_CONTAINER.start();
+
+		System.setProperty("spring.data.redis.host", REDIS_CONTAINER.getHost());
+		System.setProperty("spring.data.redis.port", REDIS_CONTAINER.getMappedPort(6379).toString());
 	}
 }

--- a/cakk-api/src/test/java/com/cakk/api/integration/user/SignIntegrationTest.java
+++ b/cakk-api/src/test/java/com/cakk/api/integration/user/SignIntegrationTest.java
@@ -1,0 +1,142 @@
+package com.cakk.api.integration.user;
+
+import static org.junit.Assert.*;
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.*;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.SqlGroup;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import com.cakk.api.common.annotation.TestWithDisplayName;
+import com.cakk.api.common.base.IntegrationTest;
+import com.cakk.api.dto.response.user.JwtResponse;
+import com.cakk.api.provider.jwt.JwtProvider;
+import com.cakk.api.vo.JsonWebToken;
+import com.cakk.common.enums.ReturnCode;
+import com.cakk.common.response.ApiResponse;
+import com.cakk.domain.mysql.entity.user.User;
+import com.cakk.domain.mysql.repository.reader.UserReader;
+import com.cakk.domain.redis.repository.impl.TokenRedisRepository;
+
+@SqlGroup({
+	@Sql(scripts = {
+		"/sql/insert-test-user.sql"
+	}, executionPhase = BEFORE_TEST_METHOD),
+	@Sql(scripts = "/sql/delete-all.sql", executionPhase = AFTER_TEST_METHOD)
+})
+public class SignIntegrationTest extends IntegrationTest {
+
+	private static final String API_URL = "/api/v1";
+
+	@Autowired
+	private JwtProvider jwtProvider;
+
+	@Autowired
+	private UserReader userReader;
+
+	@Autowired
+	private TokenRedisRepository tokenRedisRepository;
+
+	@TestWithDisplayName("토큰 재발급에 성공한다.")
+	void recreate() {
+		// given
+		final String url = "%s%d%s/recreate-token".formatted(BASE_URL, port, API_URL);
+		final UriComponents uriComponents = UriComponentsBuilder
+			.fromUriString(url)
+			.build();
+
+		User user = userReader.findByUserId(1L);
+		JsonWebToken jsonWebToken = jwtProvider.generateToken(user);
+
+		HttpHeaders headers = new HttpHeaders();
+		headers.set("Refresh", jsonWebToken.refreshToken());
+
+		HttpEntity request = new HttpEntity(headers);
+
+		// when
+		final ResponseEntity<ApiResponse> responseEntity = restTemplate.postForEntity(
+			uriComponents.toUriString(),
+			request,
+			ApiResponse.class);
+
+		// then
+		final ApiResponse response = objectMapper.convertValue(responseEntity.getBody(), ApiResponse.class);
+		final JwtResponse data = objectMapper.convertValue(response.getData(), JwtResponse.class);
+
+		assertEquals(HttpStatusCode.valueOf(200), responseEntity.getStatusCode());
+		assertEquals(ReturnCode.SUCCESS.getCode(), response.getReturnCode());
+		assertEquals(ReturnCode.SUCCESS.getMessage(), response.getReturnMessage());
+
+		assertNotNull(data.accessToken());
+		assertNotNull(data.refreshToken());
+		assertNotNull(data.grantType());
+	}
+
+	@TestWithDisplayName("블랙리스트인 리프레시 토큰인 경우, 토큰 재발급에 성공한다.")
+	void recreate2() {
+		// given
+		final String url = "%s%d%s/recreate-token".formatted(BASE_URL, port, API_URL);
+		final UriComponents uriComponents = UriComponentsBuilder
+			.fromUriString(url)
+			.build();
+
+		User user = userReader.findByUserId(1L);
+		JsonWebToken jsonWebToken = jwtProvider.generateToken(user);
+		tokenRedisRepository.registerBlackList(jsonWebToken.refreshToken(), jwtProvider.getRefreshTokenExpiredSecond());
+
+		HttpHeaders headers = new HttpHeaders();
+		headers.set("Refresh", jsonWebToken.refreshToken());
+
+		HttpEntity request = new HttpEntity(headers);
+
+		// when
+		final ResponseEntity<ApiResponse> responseEntity = restTemplate.postForEntity(
+			uriComponents.toUriString(),
+			request,
+			ApiResponse.class);
+
+		// then
+		final ApiResponse response = objectMapper.convertValue(responseEntity.getBody(), ApiResponse.class);
+
+		assertEquals(HttpStatusCode.valueOf(400), responseEntity.getStatusCode());
+		assertEquals(ReturnCode.BLACK_LIST_TOKEN.getCode(), response.getReturnCode());
+		assertEquals(ReturnCode.BLACK_LIST_TOKEN.getMessage(), response.getReturnMessage());
+	}
+
+	@TestWithDisplayName("잘못된 리프레시 토큰인 경우, 토큰 재발급에 성공한다.")
+	void recreate3() {
+		// given
+		final String url = "%s%d%s/recreate-token".formatted(BASE_URL, port, API_URL);
+		final UriComponents uriComponents = UriComponentsBuilder
+			.fromUriString(url)
+			.build();
+
+		String refreshToken = "false token";
+
+		HttpHeaders headers = new HttpHeaders();
+		headers.set("Refresh", refreshToken);
+
+		HttpEntity request = new HttpEntity(headers);
+
+		// when
+		final ResponseEntity<ApiResponse> responseEntity = restTemplate.postForEntity(
+			uriComponents.toUriString(),
+			request,
+			ApiResponse.class);
+
+		// then
+		final ApiResponse response = objectMapper.convertValue(responseEntity.getBody(), ApiResponse.class);
+
+		assertEquals(HttpStatusCode.valueOf(400), responseEntity.getStatusCode());
+		assertEquals(ReturnCode.WRONG_JWT_TOKEN.getCode(), response.getReturnCode());
+		assertEquals(ReturnCode.WRONG_JWT_TOKEN.getMessage(), response.getReturnMessage());
+	}
+
+
+}

--- a/cakk-api/src/test/java/com/cakk/api/service/user/UserServiceTest.java
+++ b/cakk-api/src/test/java/com/cakk/api/service/user/UserServiceTest.java
@@ -177,7 +177,6 @@ class UserServiceTest extends ServiceTest {
 			.sample();
 
 		doReturn(false).when(tokenRedisRepository).isBlackListToken(refreshToken);
-		doNothing().when(tokenRedisRepository).registerBlackList(refreshToken, anyLong());
 		doReturn(11111L).when(jwtProvider).getRefreshTokenExpiredSecond();
 		doReturn(user).when(jwtProvider).getUser(refreshToken);
 		doReturn(jwt).when(jwtProvider).generateToken(user);
@@ -229,5 +228,22 @@ class UserServiceTest extends ServiceTest {
 
 		verify(jwtProvider, times(1)).getUser(refreshToken);
 		verify(jwtProvider, times(0)).generateToken(any());
+	}
+
+	@TestWithDisplayName("리프레시 토큰이 블랙리스트에 있는 경우, 토큰 재발급에 실패한다")
+	void recreateToken4() {
+		// given
+		final String refreshToken = "refresh token";
+
+		doReturn(true).when(tokenRedisRepository).isBlackListToken(refreshToken);
+
+		// then
+		Assertions.assertThrows(
+			CakkException.class,
+			() -> userService.recreateToken(refreshToken),
+			ReturnCode.BLACK_LIST_TOKEN.getMessage());
+
+		verify(tokenRedisRepository, times(1)).isBlackListToken(refreshToken);
+		verify(jwtProvider, times(0)).getUser(refreshToken);
 	}
 }

--- a/cakk-api/src/test/resources/application-test.yml
+++ b/cakk-api/src/test/resources/application-test.yml
@@ -1,9 +1,4 @@
 spring:
-  data:
-    redis:
-      host: 127.0.0.1
-      port: 6379
-
   datasource:
     driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
     url: jdbc:tc:mysql:8.0:///cakk

--- a/cakk-common/src/main/java/com/cakk/common/enums/ReturnCode.java
+++ b/cakk-common/src/main/java/com/cakk/common/enums/ReturnCode.java
@@ -16,6 +16,8 @@ public enum ReturnCode {
 	EMPTY_AUTH_JWT("1103", "인증 정보가 비어있는 jwt 토큰입니다."),
 	EMPTY_USER("1104", "비어있는 유저 정보로 jwt 토큰을 생성할 수 없습니다."),
 	INVALID_KEY("1105", "잘못된 key 입니다"),
+	EMPTY_REFRESH("1106", "리프레시 토큰이 존재하지 않습니다."),
+	BLACK_LIST_TOKEN("1107", "블랙 리스트에 등록된 토큰 입니다."),
 
 	// 공통 유저 관련 (1200 ~ 1250)
 	WRONG_PROVIDER("1200", "잘못된 인증 제공자 입니다."),

--- a/cakk-domain/redis/src/main/java/com/cakk/domain/redis/config/RedisConfig.java
+++ b/cakk-domain/redis/src/main/java/com/cakk/domain/redis/config/RedisConfig.java
@@ -36,8 +36,8 @@ public class RedisConfig {
 	}
 
 	@Bean
-	public RedisTemplate<String, ?> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
-		RedisTemplate<String, ?> redisTemplate = new RedisTemplate<>();
+	public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+		RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
 
 		redisTemplate.setConnectionFactory(redisConnectionFactory);
 		redisTemplate.setKeySerializer(new StringRedisSerializer());

--- a/cakk-domain/redis/src/main/java/com/cakk/domain/redis/repository/impl/TokenRedisRepository.java
+++ b/cakk-domain/redis/src/main/java/com/cakk/domain/redis/repository/impl/TokenRedisRepository.java
@@ -26,6 +26,14 @@ public class TokenRedisRepository implements RedisValueRepository<String> {
 		valueOperations = redisTemplate.opsForValue();
 	}
 
+	public void registerBlackList(String token, long timeout) {
+		save(token, "token", timeout, TimeUnit.MILLISECONDS);
+	}
+
+	public Boolean isBlackListToken(String token) {
+		return existByKey(token);
+	}
+
 	@Override
 	public void save(String key, String value, long timeout, TimeUnit unit) {
 		valueOperations.set(key, value, timeout, unit);


### PR DESCRIPTION
> ### Issue Number

#44

> ### Description

Refresh Token을 활용한 토큰 재발급 기능을 구현하였습니다. 다만, access token 과 refresh token의 차이가 없는 것 같아 이 부분에 대한 수정을 추후에 할 예정입니다. 

> ### Core Code

```java
	@Transactional(readOnly = true)
	public JwtResponse recreateToken(final String refreshToken) {
		final boolean isBlackList = tokenRedisRepository.isBlackListToken(refreshToken);

		if (isBlackList) {
			throw new CakkException(ReturnCode.BLACK_LIST_TOKEN);
		}

		final User user = jwtProvider.getUser(refreshToken);
		final long expiredSecond = jwtProvider.getRefreshTokenExpiredSecond();

		tokenRedisRepository.registerBlackList(refreshToken, expiredSecond);

		return JwtResponse.from(jwtProvider.generateToken(user));
	}
```

> ### etc
