### PR TITLE
Feature: 인기 검색어 조회 API 구현

### DIFF
--- a/cakk-api/src/main/java/com/cakk/api/controller/search/KeywordController.java
+++ b/cakk-api/src/main/java/com/cakk/api/controller/search/KeywordController.java
@@ -1,0 +1,32 @@
+package com.cakk.api.controller.search;
+
+import jakarta.validation.Valid;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+
+import com.cakk.api.dto.request.search.TopSearchedListRequest;
+import com.cakk.api.dto.response.search.TopSearchedListResponse;
+import com.cakk.api.service.search.KeywordService;
+import com.cakk.common.response.ApiResponse;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/search")
+public class KeywordController {
+
+	private final KeywordService keywordService;
+
+	@GetMapping("/top-searched")
+	public ApiResponse<TopSearchedListResponse> topSearched(
+		@ModelAttribute @Valid TopSearchedListRequest request
+	) {
+		final TopSearchedListResponse response = keywordService.findTopSearched(request);
+
+		return ApiResponse.success(response);
+	}
+}

--- a/cakk-api/src/test/java/com/cakk/api/integration/search/KeywordIntegrationTest.java
+++ b/cakk-api/src/test/java/com/cakk/api/integration/search/KeywordIntegrationTest.java
@@ -1,0 +1,94 @@
+package com.cakk.api.integration.search;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import com.cakk.api.common.annotation.TestWithDisplayName;
+import com.cakk.api.common.base.IntegrationTest;
+import com.cakk.api.dto.response.search.TopSearchedListResponse;
+import com.cakk.common.enums.ReturnCode;
+import com.cakk.common.response.ApiResponse;
+import com.cakk.domain.redis.repository.KeywordRedisRepository;
+
+public class KeywordIntegrationTest extends IntegrationTest {
+
+	private static final String API_URL = "/api/v1/search";
+
+	@Autowired
+	private KeywordRedisRepository keywordRedisRepository;
+
+	@BeforeEach
+	void setUp() {
+		IntStream.range(0, 10).forEach(i -> keywordRedisRepository.saveOrIncreaseSearchCount("1위 검색어"));
+		IntStream.range(0, 8).forEach(i -> keywordRedisRepository.saveOrIncreaseSearchCount("2위 검색어"));
+		IntStream.range(0, 6).forEach(i -> keywordRedisRepository.saveOrIncreaseSearchCount("3위 검색어"));
+		IntStream.range(0, 4).forEach(i -> keywordRedisRepository.saveOrIncreaseSearchCount("4위 검색어"));
+		IntStream.range(0, 3).forEach(i -> keywordRedisRepository.saveOrIncreaseSearchCount("5위 검색어"));
+		IntStream.range(0, 2).forEach(i -> keywordRedisRepository.saveOrIncreaseSearchCount("6위 검색어"));
+		IntStream.range(0, 1).forEach(i -> keywordRedisRepository.saveOrIncreaseSearchCount("7위 검색어"));
+	}
+
+	@TestWithDisplayName("인기 검색어를 조회한다.")
+	void topSearched() {
+		// given
+		final String url = "%s%d%s/top-searched".formatted(BASE_URL, port, API_URL);
+		final int count = 5;
+		final UriComponents uriComponents = UriComponentsBuilder
+			.fromUriString(url)
+			.queryParam("count", count)
+			.build();
+
+		// when
+		final ResponseEntity<ApiResponse> responseEntity = restTemplate.getForEntity(uriComponents.toUriString(), ApiResponse.class);
+
+		// then
+		final ApiResponse response = objectMapper.convertValue(responseEntity.getBody(), ApiResponse.class);
+		final TopSearchedListResponse data = objectMapper.convertValue(response.getData(), TopSearchedListResponse.class);
+
+		Assertions.assertEquals(HttpStatusCode.valueOf(200), responseEntity.getStatusCode());
+		Assertions.assertEquals(ReturnCode.SUCCESS.getCode(), response.getReturnCode());
+		Assertions.assertEquals(ReturnCode.SUCCESS.getMessage(), response.getReturnMessage());
+
+		assertThat(data.keywordList()).hasSizeLessThanOrEqualTo(count);
+		assertThat(data.keywordList().get(0)).isEqualTo("1위 검색어");
+		assertThat(data.keywordList().get(1)).isEqualTo("2위 검색어");
+		assertThat(data.keywordList().get(2)).isEqualTo("3위 검색어");
+		assertThat(data.keywordList().get(3)).isEqualTo("4위 검색어");
+		assertThat(data.keywordList().get(4)).isEqualTo("5위 검색어");
+	}
+
+	@TestWithDisplayName("검색 기록이 없을 경우, 인기 검색어 조회 시 빈 배열을 반환한다.")
+	void topSearched2() {
+		// given
+		keywordRedisRepository.clear();
+
+		final String url = "%s%d%s/top-searched".formatted(BASE_URL, port, API_URL);
+		final int count = 10;
+		final UriComponents uriComponents = UriComponentsBuilder
+			.fromUriString(url)
+			.queryParam("count", count)
+			.build();
+
+		// when
+		final ResponseEntity<ApiResponse> responseEntity = restTemplate.getForEntity(uriComponents.toUriString(), ApiResponse.class);
+
+		// then
+		final ApiResponse response = objectMapper.convertValue(responseEntity.getBody(), ApiResponse.class);
+		final TopSearchedListResponse data = objectMapper.convertValue(response.getData(), TopSearchedListResponse.class);
+
+		Assertions.assertEquals(HttpStatusCode.valueOf(200), responseEntity.getStatusCode());
+		Assertions.assertEquals(ReturnCode.SUCCESS.getCode(), response.getReturnCode());
+		Assertions.assertEquals(ReturnCode.SUCCESS.getMessage(), response.getReturnMessage());
+
+		assertThat(data.keywordList()).isEmpty();
+	}
+}

--- a/cakk-domain/redis/src/main/java/com/cakk/domain/redis/repository/KeywordRedisRepository.java
+++ b/cakk-domain/redis/src/main/java/com/cakk/domain/redis/repository/KeywordRedisRepository.java
@@ -24,4 +24,8 @@ public class KeywordRedisRepository {
 	public List<String> findTopSearchedLimitCount(final long count) {
 		return redisStringZSetTemplate.findAllReverseScore(key, count);
 	}
+
+	public void clear() {
+		redisStringZSetTemplate.removeAll(key);
+	}
 }

--- a/cakk-domain/redis/src/main/java/com/cakk/domain/redis/template/RedisZSetTemplate.java
+++ b/cakk-domain/redis/src/main/java/com/cakk/domain/redis/template/RedisZSetTemplate.java
@@ -9,4 +9,6 @@ public interface RedisZSetTemplate<T> {
 	void increaseScore(String key, String value, int delta);
 
 	List<T> findAllReverseScore(String key, long count);
+
+	void removeAll(String key);
 }

--- a/cakk-domain/redis/src/main/java/com/cakk/domain/redis/template/impl/RedisStringZSetTemplate.java
+++ b/cakk-domain/redis/src/main/java/com/cakk/domain/redis/template/impl/RedisStringZSetTemplate.java
@@ -48,4 +48,9 @@ public class RedisStringZSetTemplate implements RedisZSetTemplate<String> {
 
 		return List.copyOf(data);
 	}
+
+	@Override
+	public void removeAll(String key) {
+		zSetOperations.removeRangeByScore(key, 0, Double.MAX_VALUE);
+	}
 }


### PR DESCRIPTION
> ### Issue Number

#47

> ### Description

인기 검색어 조회 API를 구현하였습니다. 이전 PR에 말씀하셨던 읽기 전략과 쓰기 전략에 대해 간략히 말씀드리면 검색 기록 관련해서 DB에 따로 적재하고 있지 않고, Redis Cache에만 저장되고 있기 때문에 별다른 전략은 존재하지 않습니다. 지적해주신 바와 같이 여러 가지 원인으로 Redis에 결함이 생긴다면 인기 검색어 조회는 불가능 합니다.

> ### Core Code

```java

```

> ### etc
