### PR TITLE
Feature: 좋아요 한 케이크 목록 조회 구현

### DIFF
--- a/cakk-api/src/main/java/com/cakk/api/controller/cake/CakeController.java
+++ b/cakk-api/src/main/java/com/cakk/api/controller/cake/CakeController.java
@@ -9,8 +9,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
 
-import com.cakk.api.dto.request.cake.CakeImageSearchRequest;
 import com.cakk.api.dto.request.cake.CakeSearchByCategoryRequest;
+import com.cakk.api.dto.request.cake.CakeSearchByLocationRequest;
 import com.cakk.api.dto.request.cake.CakeSearchByShopRequest;
 import com.cakk.api.dto.response.cake.CakeImageListResponse;
 import com.cakk.api.service.cake.CakeService;
@@ -43,7 +43,7 @@ public class CakeController {
 
 	@GetMapping("/search/cakes")
 	public ApiResponse<CakeImageListResponse> searchCakes(
-		@Valid @ModelAttribute CakeImageSearchRequest request
+		@Valid @ModelAttribute CakeSearchByLocationRequest request
 	) {
 		final CakeImageListResponse response = cakeService.findCakeImagesByCursorAndSearch(request);
 

--- a/cakk-api/src/main/java/com/cakk/api/controller/user/MyPageController.java
+++ b/cakk-api/src/main/java/com/cakk/api/controller/user/MyPageController.java
@@ -4,6 +4,7 @@ import jakarta.validation.Valid;
 
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -12,8 +13,11 @@ import org.springframework.web.bind.annotation.RestController;
 import lombok.RequiredArgsConstructor;
 
 import com.cakk.api.annotation.SignInUser;
+import com.cakk.api.dto.request.like.LikeCakeSearchRequest;
 import com.cakk.api.dto.request.user.ProfileUpdateRequest;
+import com.cakk.api.dto.response.like.LikeCakeImageListResponse;
 import com.cakk.api.dto.response.user.ProfileInformationResponse;
+import com.cakk.api.service.like.LikeService;
 import com.cakk.api.service.user.UserService;
 import com.cakk.common.response.ApiResponse;
 import com.cakk.domain.mysql.entity.user.User;
@@ -24,6 +28,7 @@ import com.cakk.domain.mysql.entity.user.User;
 public class MyPageController {
 
 	private final UserService userService;
+	private final LikeService likeService;
 
 	@GetMapping
 	public ApiResponse<ProfileInformationResponse> profile(
@@ -51,5 +56,15 @@ public class MyPageController {
 		userService.withdraw(user);
 
 		return ApiResponse.success();
+	}
+
+	@GetMapping("/liked-cakes")
+	public ApiResponse<LikeCakeImageListResponse> likedCakeList(
+		@SignInUser User user,
+		@Valid @ModelAttribute LikeCakeSearchRequest request
+	) {
+		final LikeCakeImageListResponse response = likeService.findCakeImagesByCursorAndLike(request, user);
+
+		return ApiResponse.success(response);
 	}
 }

--- a/cakk-api/src/main/java/com/cakk/api/dto/request/cake/CakeSearchByLocationRequest.java
+++ b/cakk-api/src/main/java/com/cakk/api/dto/request/cake/CakeSearchByLocationRequest.java
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.Min;
 import com.cakk.api.mapper.PointMapper;
 import com.cakk.domain.mysql.dto.param.cake.CakeSearchParam;
 
-public record CakeImageSearchRequest(
+public record CakeSearchByLocationRequest(
 	Long cakeId,
 	String keyword,
 	@Min(-90) @Max(90)

--- a/cakk-api/src/main/java/com/cakk/api/dto/request/like/LikeCakeSearchRequest.java
+++ b/cakk-api/src/main/java/com/cakk/api/dto/request/like/LikeCakeSearchRequest.java
@@ -1,0 +1,10 @@
+package com.cakk.api.dto.request.like;
+
+import jakarta.validation.constraints.NotNull;
+
+public record LikeCakeSearchRequest(
+	Long cakeLikeId,
+	@NotNull
+	Integer pageSize
+) {
+}

--- a/cakk-api/src/main/java/com/cakk/api/dto/response/cake/CakeImageListResponse.java
+++ b/cakk-api/src/main/java/com/cakk/api/dto/response/cake/CakeImageListResponse.java
@@ -13,14 +13,4 @@ public record CakeImageListResponse(
 	Long lastCakeId,
 	int size
 ) {
-
-	public static CakeImageListResponse from(List<CakeImageResponseParam> cakeImages) {
-		int size = cakeImages.size();
-
-		return CakeImageListResponse.builder()
-			.cakeImages(cakeImages)
-			.lastCakeId(cakeImages.isEmpty() ? null : cakeImages.get(size - 1).cakeId())
-			.size(cakeImages.size())
-			.build();
-	}
 }

--- a/cakk-api/src/main/java/com/cakk/api/dto/response/like/LikeCakeImageListResponse.java
+++ b/cakk-api/src/main/java/com/cakk/api/dto/response/like/LikeCakeImageListResponse.java
@@ -1,0 +1,16 @@
+package com.cakk.api.dto.response.like;
+
+import java.util.List;
+
+import lombok.Builder;
+
+import com.cakk.domain.mysql.dto.param.like.LikeCakeImageResponseParam;
+
+@Builder
+public record LikeCakeImageListResponse(
+
+	List<LikeCakeImageResponseParam> cakeImages,
+	Long lastCakeLikeId,
+	int size
+) {
+}

--- a/cakk-api/src/main/java/com/cakk/api/mapper/CakeMapper.java
+++ b/cakk-api/src/main/java/com/cakk/api/mapper/CakeMapper.java
@@ -6,17 +6,29 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 import com.cakk.api.dto.response.cake.CakeImageListResponse;
+import com.cakk.api.dto.response.like.LikeCakeImageListResponse;
 import com.cakk.domain.mysql.dto.param.cake.CakeImageResponseParam;
+import com.cakk.domain.mysql.dto.param.like.LikeCakeImageResponseParam;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class CakeMapper {
 
-	public static CakeImageListResponse supplyCakeImageListResponse(List<CakeImageResponseParam> cakeImages) {
-		int size = cakeImages.size();
+	public static CakeImageListResponse supplyCakeImageListResponse(final List<CakeImageResponseParam> cakeImages) {
+		final int size = cakeImages.size();
 
 		return CakeImageListResponse.builder()
 			.cakeImages(cakeImages)
 			.lastCakeId(cakeImages.isEmpty() ? null : cakeImages.get(size - 1).cakeId())
+			.size(cakeImages.size())
+			.build();
+	}
+
+	public static LikeCakeImageListResponse supplyLikeCakeImageListResponseBy(final List<LikeCakeImageResponseParam> cakeImages) {
+		final int size = cakeImages.size();
+
+		return LikeCakeImageListResponse.builder()
+			.cakeImages(cakeImages)
+			.lastCakeLikeId(cakeImages.isEmpty() ? null : cakeImages.get(size - 1).cakeLikeId())
 			.size(cakeImages.size())
 			.build();
 	}

--- a/cakk-api/src/main/java/com/cakk/api/service/cake/CakeService.java
+++ b/cakk-api/src/main/java/com/cakk/api/service/cake/CakeService.java
@@ -3,17 +3,19 @@ package com.cakk.api.service.cake;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 
-import com.cakk.api.dto.request.cake.CakeImageSearchRequest;
 import com.cakk.api.dto.request.cake.CakeSearchByCategoryRequest;
+import com.cakk.api.dto.request.cake.CakeSearchByLocationRequest;
 import com.cakk.api.dto.request.cake.CakeSearchByShopRequest;
 import com.cakk.api.dto.response.cake.CakeImageListResponse;
 import com.cakk.api.mapper.CakeMapper;
 import com.cakk.domain.mysql.dto.param.cake.CakeImageResponseParam;
 import com.cakk.domain.mysql.repository.reader.CakeReader;
 
+@Transactional(readOnly = true)
 @Service
 @RequiredArgsConstructor
 public class CakeService {
@@ -34,7 +36,7 @@ public class CakeService {
 		return CakeMapper.supplyCakeImageListResponse(cakeImages);
 	}
 
-	public CakeImageListResponse findCakeImagesByCursorAndSearch(final CakeImageSearchRequest dto) {
+	public CakeImageListResponse findCakeImagesByCursorAndSearch(final CakeSearchByLocationRequest dto) {
 		final List<CakeImageResponseParam> cakeImages
 			= cakeReader.searchCakeImagesByCursorAndSearchKeyword(dto.toParam());
 

--- a/cakk-api/src/main/java/com/cakk/api/service/like/LikeService.java
+++ b/cakk-api/src/main/java/com/cakk/api/service/like/LikeService.java
@@ -1,0 +1,31 @@
+package com.cakk.api.service.like;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+import com.cakk.api.dto.request.like.LikeCakeSearchRequest;
+import com.cakk.api.dto.response.like.LikeCakeImageListResponse;
+import com.cakk.api.mapper.CakeMapper;
+import com.cakk.domain.mysql.dto.param.like.LikeCakeImageResponseParam;
+import com.cakk.domain.mysql.entity.user.User;
+import com.cakk.domain.mysql.repository.reader.CakeLikeReader;
+
+@RequiredArgsConstructor
+@Service
+public class LikeService {
+
+	private final CakeLikeReader cakeLikeReader;
+
+	public LikeCakeImageListResponse findCakeImagesByCursorAndLike(final LikeCakeSearchRequest dto, final User signInUser) {
+		final List<LikeCakeImageResponseParam> cakeImages = cakeLikeReader.searchCakeImagesByCursorAndLike(
+			dto.cakeLikeId(),
+			signInUser.getId(),
+			dto.pageSize()
+		);
+
+		return CakeMapper.supplyLikeCakeImageListResponseBy(cakeImages);
+	}
+}

--- a/cakk-api/src/test/java/com/cakk/api/common/base/IntegrationTest.java
+++ b/cakk-api/src/test/java/com/cakk/api/common/base/IntegrationTest.java
@@ -5,6 +5,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpHeaders;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
@@ -64,6 +65,13 @@ public abstract class IntegrationTest {
 			.plugin(new JakartaValidationPlugin())
 			.objectIntrospector(BuilderArbitraryIntrospector.INSTANCE)
 			.build();
+	}
+
+	protected HttpHeaders getAuthHeader() {
+		final HttpHeaders headers = new HttpHeaders();
+		headers.set(HttpHeaders.AUTHORIZATION, "Bearer " + getAuthToken().accessToken());
+
+		return headers;
 	}
 
 	protected JsonWebToken getAuthToken() {

--- a/cakk-api/src/test/java/com/cakk/api/common/base/ServiceTest.java
+++ b/cakk-api/src/test/java/com/cakk/api/common/base/ServiceTest.java
@@ -9,13 +9,17 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
+import net.jqwik.api.Arbitraries;
+
 import com.navercorp.fixturemonkey.FixtureMonkey;
 import com.navercorp.fixturemonkey.api.introspector.BuilderArbitraryIntrospector;
 import com.navercorp.fixturemonkey.api.introspector.ConstructorPropertiesArbitraryIntrospector;
 import com.navercorp.fixturemonkey.api.introspector.FieldReflectionArbitraryIntrospector;
 import com.navercorp.fixturemonkey.jakarta.validation.plugin.JakartaValidationPlugin;
 
+import com.cakk.common.enums.Provider;
 import com.cakk.domain.mysql.config.JpaConfig;
+import com.cakk.domain.mysql.entity.user.User;
 
 @Import(JpaConfig.class)
 @ActiveProfiles("test")
@@ -48,6 +52,14 @@ public abstract class ServiceTest {
 			.plugin(new JakartaValidationPlugin())
 			.objectIntrospector(BuilderArbitraryIntrospector.INSTANCE)
 			.build();
+	}
+
+	protected User getUser() {
+		return getReflectionMonkey().giveMeBuilder(User.class)
+			.set("id", Arbitraries.longs().greaterOrEqual(10))
+			.set("provider", Arbitraries.of(Provider.class))
+			.set("providerId", Arbitraries.strings().withCharRange('a', 'z').ofMinLength(1).ofMaxLength(50))
+			.sample();
 	}
 
 	public static Point supplyPointBy(Double latitude, Double longitude) {

--- a/cakk-api/src/test/java/com/cakk/api/integration/shop/ShopIntegrationTest.java
+++ b/cakk-api/src/test/java/com/cakk/api/integration/shop/ShopIntegrationTest.java
@@ -169,18 +169,14 @@ class ShopIntegrationTest extends IntegrationTest {
 			.fromUriString(url)
 			.path("/certification")
 			.build();
-
-		JsonWebToken jsonWebToken = getAuthToken();
-		HttpHeaders httpHeaders = new HttpHeaders();
-		httpHeaders.add(HttpHeaders.AUTHORIZATION, "Bearer " + jsonWebToken.accessToken());
-
 		CertificationRequest request = getConstructorMonkey().giveMeBuilder(CertificationRequest.class)
 			.set("businessRegistrationImageUrl", Arbitraries.strings().withCharRange('a', 'z').ofMaxLength(40).ofMinLength(1))
 			.set("idCardImageUrl", Arbitraries.strings().withCharRange('a', 'z').ofMaxLength(40).ofMinLength(1))
 			.setNull("cakeShopId")
 			.set("emergencyContact", Arbitraries.strings().withCharRange('a', 'z').ofMaxLength(11).ofMinLength(1))
 			.set("message", Arbitraries.strings().withCharRange('a', 'z').ofMaxLength(20)).sample();
-		HttpEntity<CertificationRequest> entity = new HttpEntity<>(request, httpHeaders);
+
+		HttpEntity<CertificationRequest> entity = new HttpEntity<>(request, getAuthHeader());
 
 		final ResponseEntity<ApiResponse> responseEntity = restTemplate.postForEntity(uriComponents.toUriString(), entity, ApiResponse.class);
 		final ApiResponse response = objectMapper.convertValue(responseEntity.getBody(), ApiResponse.class);
@@ -197,18 +193,14 @@ class ShopIntegrationTest extends IntegrationTest {
 			.fromUriString(url)
 			.path("/certification")
 			.build();
-
-		JsonWebToken jsonWebToken = getAuthToken();
-		HttpHeaders httpHeaders = new HttpHeaders();
-		httpHeaders.add(HttpHeaders.AUTHORIZATION, "Bearer " + jsonWebToken.accessToken());
-
-		CertificationRequest request = getConstructorMonkey().giveMeBuilder(CertificationRequest.class)
+		final CertificationRequest request = getConstructorMonkey().giveMeBuilder(CertificationRequest.class)
 			.set("businessRegistrationImageUrl", Arbitraries.strings().withCharRange('a', 'z').ofMaxLength(40).ofMinLength(1))
 			.set("idCardImageUrl", Arbitraries.strings().withCharRange('a', 'z').ofMaxLength(40).ofMinLength(1))
 			.set("cakeShopId", Arbitraries.longs().greaterOrEqual(1).lessOrEqual(3))
 			.set("emergencyContact", Arbitraries.strings().withCharRange('a', 'z').ofMaxLength(11).ofMinLength(1))
 			.set("message", Arbitraries.strings().withCharRange('a', 'z').ofMaxLength(20)).sample();
-		HttpEntity<CertificationRequest> entity = new HttpEntity<>(request, httpHeaders);
+
+		HttpEntity<CertificationRequest> entity = new HttpEntity<>(request, getAuthHeader());
 
 		final ResponseEntity<ApiResponse> responseEntity = restTemplate.postForEntity(uriComponents.toUriString(), entity, ApiResponse.class);
 		final ApiResponse response = objectMapper.convertValue(responseEntity.getBody(), ApiResponse.class);

--- a/cakk-api/src/test/java/com/cakk/api/integration/user/LikeIntegrationTest.java
+++ b/cakk-api/src/test/java/com/cakk/api/integration/user/LikeIntegrationTest.java
@@ -1,0 +1,102 @@
+package com.cakk.api.integration.user;
+
+import static org.junit.Assert.*;
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.*;
+
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.SqlGroup;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import com.cakk.api.common.annotation.TestWithDisplayName;
+import com.cakk.api.common.base.IntegrationTest;
+import com.cakk.api.dto.request.like.LikeCakeSearchRequest;
+import com.cakk.api.dto.response.like.LikeCakeImageListResponse;
+import com.cakk.common.enums.ReturnCode;
+import com.cakk.common.response.ApiResponse;
+import com.cakk.domain.mysql.dto.param.like.LikeCakeImageResponseParam;
+
+@SqlGroup({
+	@Sql(scripts = {
+		"/sql/insert-test-user.sql",
+		"/sql/insert-cake.sql",
+		"/sql/insert-like.sql"
+	}, executionPhase = BEFORE_TEST_METHOD),
+	@Sql(scripts = "/sql/delete-all.sql", executionPhase = AFTER_TEST_METHOD)
+})
+public class LikeIntegrationTest extends IntegrationTest {
+
+	private static final String API_URL = "/api/v1/me";
+
+	@TestWithDisplayName("좋아요 한 케이크 목록을 조회한다.")
+	void listByLike1() {
+		// given
+		final String url = "%s%d%s/liked-cakes".formatted(BASE_URL, port, API_URL);
+		final LikeCakeSearchRequest params = new LikeCakeSearchRequest(null, 5);
+		final UriComponents uriComponents = UriComponentsBuilder
+			.fromUriString(url)
+			.queryParam("cakeLikeId", params.cakeLikeId())
+			.queryParam("pageSize", params.pageSize())
+			.build();
+
+		// when
+		final ResponseEntity<ApiResponse> responseEntity = restTemplate.exchange(
+			uriComponents.toUriString(),
+			HttpMethod.GET,
+			new HttpEntity<>(getAuthHeader()),
+			ApiResponse.class);
+
+		// then
+		final ApiResponse response = objectMapper.convertValue(responseEntity.getBody(), ApiResponse.class);
+		final LikeCakeImageListResponse data = objectMapper.convertValue(response.getData(), LikeCakeImageListResponse.class);
+
+		assertEquals(HttpStatusCode.valueOf(200), responseEntity.getStatusCode());
+		assertEquals(ReturnCode.SUCCESS.getCode(), response.getReturnCode());
+		assertEquals(ReturnCode.SUCCESS.getMessage(), response.getReturnMessage());
+
+		final Long lastCakeLikeId = data.cakeImages().stream()
+			.map(LikeCakeImageResponseParam::cakeLikeId)
+			.min(Long::compareTo)
+			.orElse(null);
+		assertEquals(lastCakeLikeId, data.lastCakeLikeId());
+		assertEquals(params.pageSize().intValue(), data.size());
+	}
+
+	@TestWithDisplayName("좋아요 한 케이크 목록이 없을 시 빈 배열을 조회한다.")
+	void listByLike2() {
+		// given
+		final String url = "%s%d%s/liked-cakes".formatted(BASE_URL, port, API_URL);
+		final LikeCakeSearchRequest params = new LikeCakeSearchRequest(1L, 5);
+		final UriComponents uriComponents = UriComponentsBuilder
+			.fromUriString(url)
+			.queryParam("cakeLikeId", params.cakeLikeId())
+			.queryParam("pageSize", params.pageSize())
+			.build();
+
+		// when
+		final ResponseEntity<ApiResponse> responseEntity = restTemplate.exchange(
+			uriComponents.toUriString(),
+			HttpMethod.GET,
+			new HttpEntity<>(getAuthHeader()),
+			ApiResponse.class);
+
+		// then
+		final ApiResponse response = objectMapper.convertValue(responseEntity.getBody(), ApiResponse.class);
+		final LikeCakeImageListResponse data = objectMapper.convertValue(response.getData(), LikeCakeImageListResponse.class);
+
+		assertEquals(HttpStatusCode.valueOf(200), responseEntity.getStatusCode());
+		assertEquals(ReturnCode.SUCCESS.getCode(), response.getReturnCode());
+		assertEquals(ReturnCode.SUCCESS.getMessage(), response.getReturnMessage());
+
+		final Long lastCakeLikeId = data.cakeImages().stream()
+			.map(LikeCakeImageResponseParam::cakeLikeId)
+			.min(Long::compareTo)
+			.orElse(null);
+		assertEquals(lastCakeLikeId, data.lastCakeLikeId());
+		assertEquals(0, data.size());
+	}
+}

--- a/cakk-api/src/test/java/com/cakk/api/integration/user/MyPageIntegrationTest.java
+++ b/cakk-api/src/test/java/com/cakk/api/integration/user/MyPageIntegrationTest.java
@@ -47,16 +47,11 @@ class MyPageIntegrationTest extends IntegrationTest {
 			.fromUriString(url)
 			.build();
 
-		final JsonWebToken jsonWebToken = getAuthToken();
-
-		HttpHeaders headers = new HttpHeaders();
-		headers.set("Authorization", "Bearer " + jsonWebToken.accessToken());
-
 		// when
 		final ResponseEntity<ApiResponse> responseEntity = restTemplate.exchange(
 			uriComponents.toUriString(),
 			HttpMethod.GET,
-			new HttpEntity<>(headers),
+			new HttpEntity<>(getAuthHeader()),
 			ApiResponse.class);
 
 		// then
@@ -82,8 +77,6 @@ class MyPageIntegrationTest extends IntegrationTest {
 		final UriComponents uriComponents = UriComponentsBuilder
 			.fromUriString(url)
 			.build();
-
-		final JsonWebToken jsonWebToken = getAuthToken();
 		final ProfileUpdateRequest body = getConstructorMonkey().giveMeBuilder(ProfileUpdateRequest.class)
 			.set("nickname", Arbitraries.strings().withCharRange('a', 'z').ofMinLength(1).ofMaxLength(20))
 			.set("profileImageUrl", Arbitraries.strings().withCharRange('a', 'z').ofMinLength(1).ofMaxLength(200))
@@ -92,14 +85,11 @@ class MyPageIntegrationTest extends IntegrationTest {
 			.set("birthday", LocalDate.now())
 			.sample();
 
-		HttpHeaders headers = new HttpHeaders();
-		headers.set("Authorization", "Bearer " + jsonWebToken.accessToken());
-
 		// when
 		final ResponseEntity<ApiResponse> responseEntity = restTemplate.exchange(
 			uriComponents.toUriString(),
 			HttpMethod.PUT,
-			new HttpEntity<>(body, headers),
+			new HttpEntity<>(body, getAuthHeader()),
 			ApiResponse.class);
 
 		// then
@@ -124,16 +114,11 @@ class MyPageIntegrationTest extends IntegrationTest {
 			.fromUriString(url)
 			.build();
 
-		final JsonWebToken jsonWebToken = getAuthToken();
-
-		HttpHeaders headers = new HttpHeaders();
-		headers.set("Authorization", "Bearer " + jsonWebToken.accessToken());
-
 		// when
 		final ResponseEntity<ApiResponse> responseEntity = restTemplate.exchange(
 			uriComponents.toUriString(),
 			HttpMethod.DELETE,
-			new HttpEntity<>(headers),
+			new HttpEntity<>(getAuthHeader()),
 			ApiResponse.class);
 
 		// then

--- a/cakk-api/src/test/java/com/cakk/api/service/like/LikeServiceTest.java
+++ b/cakk-api/src/test/java/com/cakk/api/service/like/LikeServiceTest.java
@@ -1,0 +1,101 @@
+package com.cakk.api.service.like;
+
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import net.jqwik.api.Arbitraries;
+
+import com.cakk.api.common.annotation.TestWithDisplayName;
+import com.cakk.api.common.base.ServiceTest;
+import com.cakk.api.dto.request.like.LikeCakeSearchRequest;
+import com.cakk.api.dto.response.like.LikeCakeImageListResponse;
+import com.cakk.domain.mysql.dto.param.like.LikeCakeImageResponseParam;
+import com.cakk.domain.mysql.entity.user.User;
+import com.cakk.domain.mysql.repository.reader.CakeLikeReader;
+
+@DisplayName("좋아요 기능 관련 비즈니스 로직 테스트")
+public class LikeServiceTest extends ServiceTest {
+
+	@InjectMocks
+	private LikeService likeService;
+
+	@Mock
+	private CakeLikeReader cakeLikeReader;
+
+	@TestWithDisplayName("좋아요 한 케이크 목록을 조회한다.")
+	void findCakeImagesByCursorAndLike() {
+		final LikeCakeSearchRequest dto = new LikeCakeSearchRequest(null, 5);
+		final User user = getUser();
+		final List<LikeCakeImageResponseParam> cakeImages =
+			getConstructorMonkey().giveMeBuilder(LikeCakeImageResponseParam.class)
+				.set("cakeShopId", Arbitraries.longs().greaterOrEqual(1))
+				.set("cakeId", Arbitraries.longs().greaterOrEqual(1))
+				.set("cakeLikeId", Arbitraries.longs().greaterOrEqual(1))
+				.set("cakeImageUrl", Arbitraries.strings().alpha().ofMinLength(10).ofMaxLength(20))
+				.sampleList(5);
+
+		doReturn(cakeImages)
+			.when(cakeLikeReader)
+			.searchCakeImagesByCursorAndLike(dto.cakeLikeId(), user.getId(), dto.pageSize());
+
+		// when
+		final LikeCakeImageListResponse result = likeService.findCakeImagesByCursorAndLike(dto, user);
+
+		// then
+		Assertions.assertEquals(cakeImages, result.cakeImages());
+		Assertions.assertNotNull(result.lastCakeLikeId());
+
+		verify(cakeLikeReader, times(1)).searchCakeImagesByCursorAndLike(dto.cakeLikeId(), user.getId(), dto.pageSize());
+	}
+
+	@TestWithDisplayName("좋아요 한 케이크 목록 n번째 페이지를 조회한다.")
+	void findCakeImagesByCursorAndLike2() {
+		final LikeCakeSearchRequest dto = new LikeCakeSearchRequest(12L, 5);
+		final User user = getUser();
+		final List<LikeCakeImageResponseParam> cakeImages =
+			getConstructorMonkey().giveMeBuilder(LikeCakeImageResponseParam.class)
+				.set("cakeShopId", Arbitraries.longs().greaterOrEqual(1))
+				.set("cakeId", Arbitraries.longs().greaterOrEqual(1))
+				.set("cakeLikeId", Arbitraries.longs().between(1, 11))
+				.set("cakeImageUrl", Arbitraries.strings().alpha().ofMinLength(10).ofMaxLength(20))
+				.sampleList(5);
+
+		doReturn(cakeImages)
+			.when(cakeLikeReader)
+			.searchCakeImagesByCursorAndLike(dto.cakeLikeId(), user.getId(), dto.pageSize());
+
+		// when
+		final LikeCakeImageListResponse result = likeService.findCakeImagesByCursorAndLike(dto, user);
+
+		// then
+		Assertions.assertEquals(cakeImages, result.cakeImages());
+		Assertions.assertNotNull(result.lastCakeLikeId());
+
+		verify(cakeLikeReader, times(1)).searchCakeImagesByCursorAndLike(dto.cakeLikeId(), user.getId(), dto.pageSize());
+	}
+
+	@TestWithDisplayName("좋아요 한 케이크가 없을 때 목록 조회 시 빈 배열을 반환한다.")
+	void findCakeImagesByCursorAndLike3() {
+		final LikeCakeSearchRequest dto = new LikeCakeSearchRequest(5L, 5);
+		final User user = getUser();
+
+		doReturn(List.of())
+			.when(cakeLikeReader)
+			.searchCakeImagesByCursorAndLike(dto.cakeLikeId(), user.getId(), dto.pageSize());
+
+		// when
+		final LikeCakeImageListResponse result = likeService.findCakeImagesByCursorAndLike(dto, user);
+
+		// then
+		Assertions.assertEquals(0, result.cakeImages().size());
+		Assertions.assertNull(result.lastCakeLikeId());
+
+		verify(cakeLikeReader, times(1)).searchCakeImagesByCursorAndLike(dto.cakeLikeId(), user.getId(), dto.pageSize());
+	}
+}

--- a/cakk-api/src/test/resources/sql/insert-like.sql
+++ b/cakk-api/src/test/resources/sql/insert-like.sql
@@ -1,0 +1,7 @@
+insert into cake_like (cake_like_id, cake_id, user_id, created_at)
+values (1, 3, 1, now()),
+       (2, 8, 1, now()),
+       (3, 5, 1, now()),
+       (4, 2, 1, now()),
+       (5, 9, 1, now()),
+       (6, 4, 1, now());

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/dto/param/like/LikeCakeImageResponseParam.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/dto/param/like/LikeCakeImageResponseParam.java
@@ -1,0 +1,9 @@
+package com.cakk.domain.mysql.dto.param.like;
+
+public record LikeCakeImageResponseParam(
+	Long cakeShopId,
+	Long cakeId,
+	Long cakeLikeId,
+	String cakeImageUrl
+) {
+}

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/query/CakeLikeQueryRepository.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/query/CakeLikeQueryRepository.java
@@ -1,0 +1,64 @@
+package com.cakk.domain.mysql.repository.query;
+
+import static com.cakk.domain.mysql.entity.cake.QCake.*;
+import static com.cakk.domain.mysql.entity.cake.QCakeLike.*;
+import static com.cakk.domain.mysql.entity.shop.QCakeShop.*;
+import static java.util.Objects.*;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+import com.cakk.domain.mysql.dto.param.cake.CakeImageResponseParam;
+import com.cakk.domain.mysql.dto.param.like.LikeCakeImageResponseParam;
+
+@RequiredArgsConstructor
+@Repository
+public class CakeLikeQueryRepository {
+
+	private final JPAQueryFactory queryFactory;
+
+	public List<LikeCakeImageResponseParam> searchCakeImagesByCursorAndLike(Long cakeLikeId, Long userId, int pageSize) {
+		return queryFactory
+			.select(Projections.constructor(LikeCakeImageResponseParam.class,
+				cakeShop.id,
+				cake.id,
+				cakeLike.id,
+				cake.cakeImageUrl))
+			.from(cakeLike)
+			.innerJoin(cake)
+			.on(cakeLike.cake.eq(cake))
+			.innerJoin(cakeShop)
+			.on(cake.cakeShop.eq(cakeShop))
+			.where(
+				ltCakeLikeId(cakeLikeId),
+				isLike(userId)
+			)
+			.limit(pageSize)
+			.orderBy(cakeLikeIdDesc())
+			.fetch();
+	}
+
+	private BooleanExpression ltCakeLikeId(Long cakeLikeId) {
+		if (isNull(cakeLikeId)) {
+			return null;
+		}
+
+		return cakeLike.id.lt(cakeLikeId);
+	}
+
+	private BooleanExpression isLike(Long userId) {
+		return cakeLike.user.id.eq(userId);
+	}
+
+	private OrderSpecifier<Long> cakeLikeIdDesc() {
+		return cakeLike.id.desc();
+	}
+}

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/query/CakeQueryRepository.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/query/CakeQueryRepository.java
@@ -56,8 +56,6 @@ public class CakeQueryRepository {
 			.from(cake)
 			.innerJoin(cakeShop)
 			.on(cake.cakeShop.eq(cakeShop))
-			.innerJoin(cakeCategory)
-			.on(cakeCategory.cake.eq(cake))
 			.where(
 				ltCakeId(cakeId),
 				eqCakeShopId(cakeShopId))
@@ -133,14 +131,6 @@ public class CakeQueryRepository {
 		return cake.cakeShop.id.in(cakeShopIds);
 	}
 
-	private OrderSpecifier<Long> cakeIdDesc() {
-		return cake.id.desc();
-	}
-
-	private OrderSpecifier<Integer> cakeLikeCountDesc() {
-		return cake.likeCount.desc();
-	}
-
 	private BooleanExpression containsKeywordInShopBio(String keyword) {
 		if (isNull(keyword)) {
 			return null;
@@ -171,5 +161,13 @@ public class CakeQueryRepository {
 		}
 
 		return Expressions.booleanTemplate("ST_Contains(ST_BUFFER({0}, 5000), {1})", location, cakeShop.location);
+	}
+
+	private OrderSpecifier<Long> cakeIdDesc() {
+		return cake.id.desc();
+	}
+
+	private OrderSpecifier<Integer> cakeLikeCountDesc() {
+		return cake.likeCount.desc();
 	}
 }

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/reader/CakeLikeReader.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/reader/CakeLikeReader.java
@@ -1,0 +1,20 @@
+package com.cakk.domain.mysql.repository.reader;
+
+import java.util.List;
+
+import lombok.RequiredArgsConstructor;
+
+import com.cakk.domain.mysql.annotation.Reader;
+import com.cakk.domain.mysql.dto.param.like.LikeCakeImageResponseParam;
+import com.cakk.domain.mysql.repository.query.CakeLikeQueryRepository;
+
+@RequiredArgsConstructor
+@Reader
+public class CakeLikeReader {
+
+	private final CakeLikeQueryRepository cakeLikeQueryRepository;
+
+	public List<LikeCakeImageResponseParam> searchCakeImagesByCursorAndLike(Long cakeLikeId, Long userId, int pageSize) {
+		return cakeLikeQueryRepository.searchCakeImagesByCursorAndLike(cakeLikeId, userId, pageSize);
+	}
+}


### PR DESCRIPTION
> ### Issue Number

#71

> ### Description

좋아요 한 케이크 목록 조회를 구현했습니다. 해당 구현 시 가장 신경 쓴 부분은 `도메인을 분리할 것인가?`와 `API 설계를 어떻게 할 것인가?` 였습니다. 좋아요와 관련된 기능은 다음과 같습니다.

- 좋아요 한 케이크 조회
- 좋아요 한 케이크 샵 조회
- 케이크 좋아요 or 취소
- 케이크 샵 좋아요 or 취소

조회의 경우, 기존 조회와 다르게 cake_like_id를 기준으로 페이지네이션이 이루어지고, 좋아요 혹은 좋아요 취소 기능은 새로운 행동으로 판단하여 비즈니스를 분리했습니다. 또, 조회 APi의 경우, cake 혹은 cake_shop에서 제공하는 데이터이지만, 특정 유저에 대한 데이터임을 고려하여 ~/me/liked-cake 혹은 ~/me/liked-shop 으로 설계했습니다.

추가로 기존에 getAuthToken() 이라는 공통 메서드를 IntegrationTest에 추가했었는데, Authorization 헤더를 위해 가져오는 경우가 대부분이라고 판단하여 getAuthHeader()이라는 공통 메서드를 추가하였고, 해당 메서드를 모든 통합 테스트에 적용하였습니다.

> ### Core Code

```sql
select cs1_0.shop_id,
           c1_0.cake_id,
           cl1_0.cake_like_id,
           c1_0.cake_image_url 
from cake_like cl1_0 
join cake c1_0 
on cl1_0.cake_id=c1_0.cake_id 
join cake_shop cs1_0 
on c1_0.shop_id=cs1_0.shop_id 
where cl1_0.cake_like_id < :cakeLikeId 
    and cl1_0.user_id = :userId
order by cl1_0.cake_like_id desc 
limit :pageSize
```

> ### etc
