### PR TITLE
Feature: 케이크 좋아요 기능 구현

### DIFF
--- a/cakk-api/src/main/java/com/cakk/api/service/like/LikeService.java
+++ b/cakk-api/src/main/java/com/cakk/api/service/like/LikeService.java
@@ -1,24 +1,37 @@
 package com.cakk.api.service.like;
 
+import static java.util.Objects.*;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 
 import com.cakk.api.dto.request.like.LikeCakeSearchRequest;
 import com.cakk.api.dto.response.like.LikeCakeImageListResponse;
 import com.cakk.api.mapper.CakeMapper;
+import com.cakk.common.enums.RedisKey;
 import com.cakk.domain.mysql.dto.param.like.LikeCakeImageResponseParam;
+import com.cakk.domain.mysql.entity.cake.Cake;
+import com.cakk.domain.mysql.entity.cake.CakeLike;
 import com.cakk.domain.mysql.entity.user.User;
 import com.cakk.domain.mysql.repository.reader.CakeLikeReader;
+import com.cakk.domain.mysql.repository.reader.CakeReader;
+import com.cakk.domain.mysql.repository.writer.CakeLikeWriter;
+import com.cakk.domain.redis.repository.LockRedisRepository;
 
 @RequiredArgsConstructor
 @Service
 public class LikeService {
 
+	private final CakeReader cakeReader;
 	private final CakeLikeReader cakeLikeReader;
+	private final CakeLikeWriter cakeLikeWriter;
 
+	private final LockRedisRepository lockRedisRepository;
+
+	@Transactional(readOnly = true)
 	public LikeCakeImageListResponse findCakeImagesByCursorAndLike(final LikeCakeSearchRequest dto, final User signInUser) {
 		final List<LikeCakeImageResponseParam> cakeImages = cakeLikeReader.searchCakeImagesByCursorAndLike(
 			dto.cakeLikeId(),
@@ -27,5 +40,23 @@ public class LikeService {
 		);
 
 		return CakeMapper.supplyLikeCakeImageListResponseBy(cakeImages);
+	}
+
+	@Transactional
+	public void likeCake(final User user, final Long cakeId) {
+		final Cake cake = cakeReader.findById(cakeId);
+		final CakeLike cakeLike = cakeLikeReader.findOrNullByUserAndCake(user, cake);
+
+		lockRedisRepository.executeWithLock(RedisKey.LOCK_CAKE_LIKE, 1000L,
+			() -> likeCakeOrCancel(cakeLike, user, cake)
+		);
+	}
+
+	private void likeCakeOrCancel(final CakeLike cakeLike, final User user, final Cake cake) {
+		if (isNull(cakeLike)) {
+			cakeLikeWriter.like(cake, user);
+		} else {
+			cakeLikeWriter.cancelLike(cakeLike);
+		}
 	}
 }

--- a/cakk-api/src/main/java/com/cakk/api/service/like/LikeService.java
+++ b/cakk-api/src/main/java/com/cakk/api/service/like/LikeService.java
@@ -1,6 +1,7 @@
 package com.cakk.api.service.like;
 
 import static java.util.Objects.*;
+
 import java.util.List;
 
 import org.springframework.stereotype.Service;

--- a/cakk-api/src/test/java/com/cakk/api/service/like/LikeServiceTest.java
+++ b/cakk-api/src/test/java/com/cakk/api/service/like/LikeServiceTest.java
@@ -1,5 +1,6 @@
 package com.cakk.api.service.like;
 
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import java.util.List;
@@ -15,9 +16,16 @@ import com.cakk.api.common.annotation.TestWithDisplayName;
 import com.cakk.api.common.base.ServiceTest;
 import com.cakk.api.dto.request.like.LikeCakeSearchRequest;
 import com.cakk.api.dto.response.like.LikeCakeImageListResponse;
+import com.cakk.common.enums.RedisKey;
+import com.cakk.common.enums.ReturnCode;
+import com.cakk.common.exception.CakkException;
 import com.cakk.domain.mysql.dto.param.like.LikeCakeImageResponseParam;
+import com.cakk.domain.mysql.entity.cake.Cake;
 import com.cakk.domain.mysql.entity.user.User;
 import com.cakk.domain.mysql.repository.reader.CakeLikeReader;
+import com.cakk.domain.mysql.repository.reader.CakeReader;
+import com.cakk.domain.mysql.repository.writer.CakeLikeWriter;
+import com.cakk.domain.redis.repository.LockRedisRepository;
 
 @DisplayName("좋아요 기능 관련 비즈니스 로직 테스트")
 public class LikeServiceTest extends ServiceTest {
@@ -26,7 +34,16 @@ public class LikeServiceTest extends ServiceTest {
 	private LikeService likeService;
 
 	@Mock
+	private CakeReader cakeReader;
+
+	@Mock
 	private CakeLikeReader cakeLikeReader;
+
+	@Mock
+	private CakeLikeWriter cakeLikeWriter;
+
+	@Mock
+	private LockRedisRepository lockRedisRepository;
 
 	@TestWithDisplayName("좋아요 한 케이크 목록을 조회한다.")
 	void findCakeImagesByCursorAndLike() {
@@ -51,7 +68,8 @@ public class LikeServiceTest extends ServiceTest {
 		Assertions.assertEquals(cakeImages, result.cakeImages());
 		Assertions.assertNotNull(result.lastCakeLikeId());
 
-		verify(cakeLikeReader, times(1)).searchCakeImagesByCursorAndLike(dto.cakeLikeId(), user.getId(), dto.pageSize());
+		verify(cakeLikeReader, times(1))
+			.searchCakeImagesByCursorAndLike(dto.cakeLikeId(), user.getId(), dto.pageSize());
 	}
 
 	@TestWithDisplayName("좋아요 한 케이크 목록 n번째 페이지를 조회한다.")
@@ -77,7 +95,8 @@ public class LikeServiceTest extends ServiceTest {
 		Assertions.assertEquals(cakeImages, result.cakeImages());
 		Assertions.assertNotNull(result.lastCakeLikeId());
 
-		verify(cakeLikeReader, times(1)).searchCakeImagesByCursorAndLike(dto.cakeLikeId(), user.getId(), dto.pageSize());
+		verify(cakeLikeReader, times(1))
+			.searchCakeImagesByCursorAndLike(dto.cakeLikeId(), user.getId(), dto.pageSize());
 	}
 
 	@TestWithDisplayName("좋아요 한 케이크가 없을 때 목록 조회 시 빈 배열을 반환한다.")
@@ -96,6 +115,46 @@ public class LikeServiceTest extends ServiceTest {
 		Assertions.assertEquals(0, result.cakeImages().size());
 		Assertions.assertNull(result.lastCakeLikeId());
 
-		verify(cakeLikeReader, times(1)).searchCakeImagesByCursorAndLike(dto.cakeLikeId(), user.getId(), dto.pageSize());
+		verify(cakeLikeReader, times(1))
+			.searchCakeImagesByCursorAndLike(dto.cakeLikeId(), user.getId(), dto.pageSize());
+	}
+
+	@TestWithDisplayName("케이크에 대하여 좋아요를 동작한다.")
+	void likeCake1() {
+		// given
+		final User user = getUser();
+		final Long cakeId = 1L;
+		final Cake cake = getConstructorMonkey().giveMeOne(Cake.class);
+
+		doReturn(cake).when(cakeReader).findById(cakeId);
+		doReturn(null).when(cakeLikeReader).findOrNullByUserAndCake(user, cake);
+		doNothing().when(lockRedisRepository).executeWithLock(any(RedisKey.class), anyLong(), any(Runnable.class));
+
+		// when & then
+		assertDoesNotThrow(() -> likeService.likeCake(user, cakeId));
+
+		verify(cakeReader, times(1)).findById(cakeId);
+		verify(cakeLikeReader, times(1)).findOrNullByUserAndCake(user, cake);
+		verify(lockRedisRepository, times(1)).executeWithLock(any(RedisKey.class), anyLong(), any(Runnable.class));
+	}
+
+	@TestWithDisplayName("해당 케이크가 없으면 좋아요 동작을 실패한다.")
+	void likeCake2() {
+		// given
+		final User user = getUser();
+		final Long cakeId = 1L;
+		final Cake cake = getConstructorMonkey().giveMeOne(Cake.class);
+
+		doThrow(new CakkException(ReturnCode.NOT_EXIST_CAKE)).when(cakeReader).findById(cakeId);
+
+		// when & then
+		assertThrows(
+			CakkException.class,
+			() -> likeService.likeCake(user, cakeId),
+			ReturnCode.NOT_EXIST_CAKE.getMessage());
+
+		verify(cakeReader, times(1)).findById(cakeId);
+		verify(cakeLikeReader, times(0)).findOrNullByUserAndCake(user, cake);
+		verify(lockRedisRepository, times(0)).executeWithLock(any(RedisKey.class), anyLong(), any(Runnable.class));
 	}
 }

--- a/cakk-common/src/main/java/com/cakk/common/enums/RedisKey.java
+++ b/cakk-common/src/main/java/com/cakk/common/enums/RedisKey.java
@@ -7,7 +7,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum RedisKey {
 
-	SEARCH_KEYWORD("SEARCH::keyword");
+	SEARCH_KEYWORD("SEARCH::keyword"),
+	LOCK_CAKE_LIKE("LOCK::cake-like"),
+	LOCK_SHOP_LIKE("LOCK::shop-like");
 
 	private final String value;
 }

--- a/cakk-common/src/main/java/com/cakk/common/enums/ReturnCode.java
+++ b/cakk-common/src/main/java/com/cakk/common/enums/ReturnCode.java
@@ -35,7 +35,8 @@ public enum ReturnCode {
 	WRONG_PARAMETER("9000", "잘못된 파라미터 입니다."),
 	METHOD_NOT_ALLOWED("9001", "허용되지 않은 메소드 입니다."),
 
-	// 서버 에러 (9998, 9999)
+	// 서버 에러 (9997 ~ 9999)
+	LOCK_RESOURCES_ERROR("9997", "락에 의해 리소스을 점유할 수 없습니다."),
 	INTERNAL_SERVER_ERROR("9998", "내부 서버 에러 입니다."),
 	EXTERNAL_SERVER_ERROR("9999", "외부 서버 에러 입니다.");
 

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/entity/cake/Cake.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/entity/cake/Cake.java
@@ -51,4 +51,12 @@ public class Cake extends AuditEntity {
 		this.cakeShop = cakeShop;
 		this.likeCount = 0;
 	}
+
+	public void increaseLikeCount() {
+		this.likeCount++;
+	}
+
+	public void decreaseLikeCount() {
+		this.likeCount--;
+	}
 }

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/jpa/CakeLikeJpaRepository.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/jpa/CakeLikeJpaRepository.java
@@ -1,13 +1,17 @@
 package com.cakk.domain.mysql.repository.jpa;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import com.cakk.domain.mysql.entity.cake.Cake;
 import com.cakk.domain.mysql.entity.cake.CakeLike;
 import com.cakk.domain.mysql.entity.user.User;
 
 public interface CakeLikeJpaRepository extends JpaRepository<CakeLike, Long> {
 
 	List<CakeLike> findAllByUser(User user);
+
+	Optional<CakeLike> findByUserAndCake(User user, Cake cake);
 }

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/reader/CakeLikeReader.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/reader/CakeLikeReader.java
@@ -6,15 +6,24 @@ import lombok.RequiredArgsConstructor;
 
 import com.cakk.domain.mysql.annotation.Reader;
 import com.cakk.domain.mysql.dto.param.like.LikeCakeImageResponseParam;
+import com.cakk.domain.mysql.entity.cake.Cake;
+import com.cakk.domain.mysql.entity.cake.CakeLike;
+import com.cakk.domain.mysql.entity.user.User;
+import com.cakk.domain.mysql.repository.jpa.CakeLikeJpaRepository;
 import com.cakk.domain.mysql.repository.query.CakeLikeQueryRepository;
 
 @RequiredArgsConstructor
 @Reader
 public class CakeLikeReader {
 
+	private final CakeLikeJpaRepository cakeLikeJpaRepository;
 	private final CakeLikeQueryRepository cakeLikeQueryRepository;
 
-	public List<LikeCakeImageResponseParam> searchCakeImagesByCursorAndLike(Long cakeLikeId, Long userId, int pageSize) {
+	public List<LikeCakeImageResponseParam> searchCakeImagesByCursorAndLike(final Long cakeLikeId, final Long userId, final int pageSize) {
 		return cakeLikeQueryRepository.searchCakeImagesByCursorAndLike(cakeLikeId, userId, pageSize);
+	}
+
+	public CakeLike findOrNullByUserAndCake(final User user, final Cake cake) {
+		return cakeLikeJpaRepository.findByUserAndCake(user, cake).orElse(null);
 	}
 }

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/writer/CakeLikeWriter.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/writer/CakeLikeWriter.java
@@ -7,6 +7,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 
 import com.cakk.domain.mysql.annotation.Writer;
+import com.cakk.domain.mysql.entity.cake.Cake;
 import com.cakk.domain.mysql.entity.cake.CakeLike;
 import com.cakk.domain.mysql.entity.user.User;
 import com.cakk.domain.mysql.repository.jpa.CakeLikeJpaRepository;
@@ -16,6 +17,20 @@ import com.cakk.domain.mysql.repository.jpa.CakeLikeJpaRepository;
 public class CakeLikeWriter {
 
 	private final CakeLikeJpaRepository cakeLikeJpaRepository;
+
+	public void like(final Cake cake, final User user) {
+		final CakeLike cakeLike = new CakeLike(cake, user);
+
+		cakeLikeJpaRepository.save(cakeLike);
+		cake.increaseLikeCount();
+	}
+
+	public void cancelLike(final CakeLike cakeLike) {
+		final Cake cake = cakeLike.getCake();
+
+		cakeLikeJpaRepository.delete(cakeLike);
+		cake.decreaseLikeCount();
+	}
 
 	public void deleteAllByUser(final User user) {
 		final List<CakeLike> cakeLikes = cakeLikeJpaRepository.findAllByUser(user);

--- a/cakk-domain/redis/src/main/java/com/cakk/domain/redis/repository/LockRedisRepository.java
+++ b/cakk-domain/redis/src/main/java/com/cakk/domain/redis/repository/LockRedisRepository.java
@@ -1,0 +1,48 @@
+package com.cakk.domain.redis.repository;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import lombok.RequiredArgsConstructor;
+
+import com.cakk.common.enums.RedisKey;
+import com.cakk.common.enums.ReturnCode;
+import com.cakk.common.exception.CakkException;
+import com.cakk.domain.redis.annotation.RedisRepository;
+import com.cakk.domain.redis.template.impl.RedisStringValueTemplate;
+
+@RedisRepository
+@RequiredArgsConstructor
+public class LockRedisRepository {
+
+	private final RedisStringValueTemplate redisStringValueTemplate;
+
+	public void executeWithLock(final RedisKey key, final long timeout, Runnable task) {
+		final String lockName = key.getValue();
+
+		try {
+			getLock(lockName, timeout);
+			task.run();
+		} finally {
+			releaseLock(lockName);
+		}
+	}
+
+	private void getLock(final String key, final long timeout) {
+		final boolean result = redisStringValueTemplate.saveIfAbsent(key, "lock", timeout, TimeUnit.MILLISECONDS);
+
+		checkResult(result);
+	}
+
+	private void releaseLock(final String key) {
+		final boolean result = redisStringValueTemplate.delete(key);
+
+		checkResult(result);
+	}
+
+	private void checkResult(final boolean result) {
+		if (!result) {
+			throw new CakkException(ReturnCode.LOCK_RESOURCES_ERROR);
+		}
+	}
+}

--- a/cakk-domain/redis/src/main/java/com/cakk/domain/redis/template/RedisValueTemplate.java
+++ b/cakk-domain/redis/src/main/java/com/cakk/domain/redis/template/RedisValueTemplate.java
@@ -9,6 +9,8 @@ public interface RedisValueTemplate<T> {
 
 	void save(String key, T value, long timeout, TimeUnit unit);
 
+	Boolean saveIfAbsent(String key, T value, long timeout, TimeUnit unit);
+
 	T findByKey(String key);
 
 	Boolean existByKey(String key);

--- a/cakk-domain/redis/src/main/java/com/cakk/domain/redis/template/impl/RedisStringValueTemplate.java
+++ b/cakk-domain/redis/src/main/java/com/cakk/domain/redis/template/impl/RedisStringValueTemplate.java
@@ -32,6 +32,11 @@ public class RedisStringValueTemplate implements RedisValueTemplate<String> {
 	}
 
 	@Override
+	public Boolean saveIfAbsent(String key, String value, long timeout, TimeUnit unit) {
+		return valueOperations.setIfAbsent(key, value, timeout, unit);
+	}
+
+	@Override
 	public String findByKey(final String key) {
 		final String value = valueOperations.get(key);
 


### PR DESCRIPTION
> ### Issue Number

#74

> ### Description

`케이크 좋아요`를 구현하였습니다. 현실적으로 동시성 문제가 발생하진 않을 것 같지만, 서버 개발자의 덕목은 `상상 버그`라고 생각하여 동시성 처리를 추가했습니다. Lettuce를 활용하여 동시성을 해결했습니다. 동시성과 관련된 테스트는 다음 PR에서 통합테스트와 함께 진행할 예정입니다. 

> ### Core Code

```java
	@Transactional
	public void likeCake(final User user, final Long cakeId) {
		final Cake cake = cakeReader.findById(cakeId);
		final CakeLike cakeLike = cakeLikeReader.findOrNullByUserAndCake(user, cake);

		lockRedisRepository.executeWithLock(RedisKey.LOCK_CAKE_LIKE, 1000L,
			() -> likeCakeOrCancel(cakeLike, user, cake)
		);
	}
```

> ### etc
