### PR TITLE
Feature: 케이크샵 검색 조회 기능 추가

### DIFF
--- a/cakk-api/src/main/java/com/cakk/api/annotation/OperationDay.java
+++ b/cakk-api/src/main/java/com/cakk/api/annotation/OperationDay.java
@@ -13,7 +13,7 @@ import com.cakk.api.validator.OperationValidator;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)
 @Constraint(validatedBy = OperationValidator.class)
-public @interface OperationDays {
+public @interface OperationDay {
 
 	String message() default "영업 일자 형식이 잘못됐습니다.";
 

--- a/cakk-api/src/main/java/com/cakk/api/controller/shop/ShopController.java
+++ b/cakk-api/src/main/java/com/cakk/api/controller/shop/ShopController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 import lombok.RequiredArgsConstructor;
 
 import com.cakk.api.annotation.SignInUser;
+import com.cakk.api.dto.request.shop.CakeShopSearchRequest;
 import com.cakk.api.dto.request.shop.CreateShopRequest;
 import com.cakk.api.dto.request.shop.PromotionRequest;
 import com.cakk.api.dto.request.shop.SearchShopByLocationRequest;
@@ -22,6 +23,7 @@ import com.cakk.api.dto.request.user.CertificationRequest;
 import com.cakk.api.dto.response.shop.CakeShopByMapResponse;
 import com.cakk.api.dto.response.shop.CakeShopDetailResponse;
 import com.cakk.api.dto.response.shop.CakeShopInfoResponse;
+import com.cakk.api.dto.response.shop.CakeShopSearchResponse;
 import com.cakk.api.dto.response.shop.CakeShopSimpleResponse;
 import com.cakk.api.service.like.LikeService;
 import com.cakk.api.service.shop.ShopService;
@@ -100,5 +102,13 @@ public class ShopController {
 		likeService.likeCakeShop(user, cakeShopId);
 
 		return ApiResponse.success();
+	}
+
+	@GetMapping("/search/shops")
+	public ApiResponse<CakeShopSearchResponse> searchShopByKeyword(
+		@Valid @ModelAttribute CakeShopSearchRequest request
+	) {
+		final CakeShopSearchResponse response = shopService.searchShopByKeyword(request);
+		return ApiResponse.success(response);
 	}
 }

--- a/cakk-api/src/main/java/com/cakk/api/dto/request/cake/CakeSearchByLocationRequest.java
+++ b/cakk-api/src/main/java/com/cakk/api/dto/request/cake/CakeSearchByLocationRequest.java
@@ -2,6 +2,7 @@ package com.cakk.api.dto.request.cake;
 
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 
 import com.cakk.api.mapper.PointMapper;
 import com.cakk.domain.mysql.dto.param.cake.CakeSearchParam;
@@ -9,16 +10,16 @@ import com.cakk.domain.mysql.dto.param.cake.CakeSearchParam;
 public record CakeSearchByLocationRequest(
 	Long cakeId,
 	String keyword,
-	@Min(-90) @Max(90)
+	@NotNull @Min(-90) @Max(90)
 	Double latitude,
-	@Min(-180) @Max(180)
+	@NotNull @Min(-180) @Max(180)
 	Double longitude,
 	Integer pageSize
 ) {
 
 	public CakeSearchParam toParam() {
 		return new CakeSearchParam(
-			cakeId == null ? 0 : cakeId,
+			cakeId,
 			keyword,
 			PointMapper.supplyPointBy(latitude, longitude),
 			pageSize == null ? 10 : pageSize

--- a/cakk-api/src/main/java/com/cakk/api/dto/request/cake/CakeSearchByLocationRequest.java
+++ b/cakk-api/src/main/java/com/cakk/api/dto/request/cake/CakeSearchByLocationRequest.java
@@ -21,7 +21,7 @@ public record CakeSearchByLocationRequest(
 			cakeId == null ? 0 : cakeId,
 			keyword,
 			PointMapper.supplyPointBy(latitude, longitude),
-			pageSize
+			pageSize == null ? 10 : pageSize
 		);
 	}
 }

--- a/cakk-api/src/main/java/com/cakk/api/dto/request/shop/CakeShopSearchRequest.java
+++ b/cakk-api/src/main/java/com/cakk/api/dto/request/shop/CakeShopSearchRequest.java
@@ -2,6 +2,7 @@ package com.cakk.api.dto.request.shop;
 
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 
 import com.cakk.api.mapper.PointMapper;
 import com.cakk.domain.mysql.dto.param.shop.CakeShopSearchParam;
@@ -9,16 +10,16 @@ import com.cakk.domain.mysql.dto.param.shop.CakeShopSearchParam;
 public record CakeShopSearchRequest(
 	Long cakeShopId,
 	String keyword,
-	@Min(-90) @Max(90)
+	@NotNull @Min(-90) @Max(90)
 	Double latitude,
-	@Min(-180) @Max(180)
+	@NotNull @Min(-180) @Max(180)
 	Double longitude,
 	Integer pageSize
 ) {
 
 	public CakeShopSearchParam toParam() {
 		return new CakeShopSearchParam(
-			cakeShopId == null ? 0 : cakeShopId,
+			cakeShopId,
 			keyword,
 			PointMapper.supplyPointBy(latitude, longitude),
 			pageSize

--- a/cakk-api/src/main/java/com/cakk/api/dto/request/shop/CakeShopSearchRequest.java
+++ b/cakk-api/src/main/java/com/cakk/api/dto/request/shop/CakeShopSearchRequest.java
@@ -1,10 +1,10 @@
 package com.cakk.api.dto.request.shop;
 
-import com.cakk.api.mapper.PointMapper;
-import com.cakk.domain.mysql.dto.param.shop.CakeShopSearchParam;
-
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+
+import com.cakk.api.mapper.PointMapper;
+import com.cakk.domain.mysql.dto.param.shop.CakeShopSearchParam;
 
 public record CakeShopSearchRequest(
 	Long cakeShopId,

--- a/cakk-api/src/main/java/com/cakk/api/dto/request/shop/CakeShopSearchRequest.java
+++ b/cakk-api/src/main/java/com/cakk/api/dto/request/shop/CakeShopSearchRequest.java
@@ -1,0 +1,27 @@
+package com.cakk.api.dto.request.shop;
+
+import com.cakk.api.mapper.PointMapper;
+import com.cakk.domain.mysql.dto.param.shop.CakeShopSearchParam;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+
+public record CakeShopSearchRequest(
+	Long cakeShopId,
+	String keyword,
+	@Min(-90) @Max(90)
+	Double latitude,
+	@Min(-180) @Max(180)
+	Double longitude,
+	Integer pageSize
+) {
+
+	public CakeShopSearchParam toParam() {
+		return new CakeShopSearchParam(
+			cakeShopId == null ? 0 : cakeShopId,
+			keyword,
+			PointMapper.supplyPointBy(latitude, longitude),
+			pageSize
+		);
+	}
+}

--- a/cakk-api/src/main/java/com/cakk/api/dto/request/shop/CreateShopRequest.java
+++ b/cakk-api/src/main/java/com/cakk/api/dto/request/shop/CreateShopRequest.java
@@ -4,7 +4,6 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 import com.cakk.api.annotation.OperationDay;
-import com.cakk.common.dto.OperationDays;
 
 public record CreateShopRequest(
 

--- a/cakk-api/src/main/java/com/cakk/api/dto/request/shop/CreateShopRequest.java
+++ b/cakk-api/src/main/java/com/cakk/api/dto/request/shop/CreateShopRequest.java
@@ -4,13 +4,14 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 import com.cakk.api.annotation.OperationDay;
+import com.cakk.common.dto.OperationDays;
 
 public record CreateShopRequest(
 
 	@NotBlank
 	String businessNumber,
 	@OperationDay
-	OperationDayRequest operationDayRequest,
+	OperationDays operationDays,
 	@NotBlank
 	String shopName,
 	String shopBio,

--- a/cakk-api/src/main/java/com/cakk/api/dto/request/shop/CreateShopRequest.java
+++ b/cakk-api/src/main/java/com/cakk/api/dto/request/shop/CreateShopRequest.java
@@ -3,13 +3,13 @@ package com.cakk.api.dto.request.shop;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
-import com.cakk.api.annotation.OperationDays;
+import com.cakk.api.annotation.OperationDay;
 
 public record CreateShopRequest(
 
 	@NotBlank
 	String businessNumber,
-	@OperationDays
+	@OperationDay
 	OperationDayRequest operationDayRequest,
 	@NotBlank
 	String shopName,

--- a/cakk-api/src/main/java/com/cakk/api/dto/request/shop/OperationDays.java
+++ b/cakk-api/src/main/java/com/cakk/api/dto/request/shop/OperationDays.java
@@ -1,4 +1,4 @@
-package com.cakk.common.dto;
+package com.cakk.api.dto.request.shop;
 
 import java.time.LocalTime;
 import java.util.List;

--- a/cakk-api/src/main/java/com/cakk/api/dto/request/shop/SearchShopByLocationRequest.java
+++ b/cakk-api/src/main/java/com/cakk/api/dto/request/shop/SearchShopByLocationRequest.java
@@ -2,12 +2,13 @@ package com.cakk.api.dto.request.shop;
 
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 
 public record SearchShopByLocationRequest(
 
-	@Min(-90) @Max(90)
+	@NotNull @Min(-90) @Max(90)
 	Double latitude,
-	@Min(-180) @Max(180)
+	@NotNull @Min(-180) @Max(180)
 	Double longitude
 ) {
 }

--- a/cakk-api/src/main/java/com/cakk/api/dto/response/shop/CakeShopByMapResponse.java
+++ b/cakk-api/src/main/java/com/cakk/api/dto/response/shop/CakeShopByMapResponse.java
@@ -2,11 +2,11 @@ package com.cakk.api.dto.response.shop;
 
 import java.util.List;
 
-import com.cakk.domain.mysql.dto.param.shop.CakeShopMapParam;
+import com.cakk.domain.mysql.dto.param.shop.CakeShopParam;
 
 
 public record CakeShopByMapResponse(
-	List<CakeShopMapParam> cakeShops
+	List<CakeShopParam> cakeShops
 ) {
 }
 

--- a/cakk-api/src/main/java/com/cakk/api/dto/response/shop/CakeShopSearchResponse.java
+++ b/cakk-api/src/main/java/com/cakk/api/dto/response/shop/CakeShopSearchResponse.java
@@ -2,9 +2,9 @@ package com.cakk.api.dto.response.shop;
 
 import java.util.List;
 
-import com.cakk.domain.mysql.dto.param.shop.CakeShopParam;
-
 import lombok.Builder;
+
+import com.cakk.domain.mysql.dto.param.shop.CakeShopParam;
 
 @Builder
 public record CakeShopSearchResponse(

--- a/cakk-api/src/main/java/com/cakk/api/dto/response/shop/CakeShopSearchResponse.java
+++ b/cakk-api/src/main/java/com/cakk/api/dto/response/shop/CakeShopSearchResponse.java
@@ -1,0 +1,15 @@
+package com.cakk.api.dto.response.shop;
+
+import java.util.List;
+
+import com.cakk.domain.mysql.dto.param.shop.CakeShopParam;
+
+import lombok.Builder;
+
+@Builder
+public record CakeShopSearchResponse(
+	List<CakeShopParam> cakeShops,
+	Long lastCakeShopId,
+	int size
+) {
+}

--- a/cakk-api/src/main/java/com/cakk/api/mapper/PointMapper.java
+++ b/cakk-api/src/main/java/com/cakk/api/mapper/PointMapper.java
@@ -13,6 +13,9 @@ public class PointMapper {
 		SPATIAL_REFERENCE_IDENTIFIER_NUMBER);
 
 	public static Point supplyPointBy(Double latitude, Double longitude) {
+		if (latitude == null || longitude == null) {
+			return null;
+		}
 		return geometryFactory.createPoint(new Coordinate(longitude, latitude));
 	}
 }

--- a/cakk-api/src/main/java/com/cakk/api/mapper/ShopMapper.java
+++ b/cakk-api/src/main/java/com/cakk/api/mapper/ShopMapper.java
@@ -12,11 +12,13 @@ import com.cakk.api.dto.request.shop.CreateShopRequest;
 import com.cakk.api.dto.response.shop.CakeShopByMapResponse;
 import com.cakk.api.dto.response.shop.CakeShopDetailResponse;
 import com.cakk.api.dto.response.shop.CakeShopInfoResponse;
+import com.cakk.api.dto.response.shop.CakeShopSearchResponse;
 import com.cakk.api.dto.response.shop.CakeShopSimpleResponse;
 import com.cakk.common.enums.Days;
+import com.cakk.domain.mysql.dto.param.shop.CakeShopByKeywordParam;
 import com.cakk.domain.mysql.dto.param.shop.CakeShopDetailParam;
 import com.cakk.domain.mysql.dto.param.shop.CakeShopInfoParam;
-import com.cakk.domain.mysql.dto.param.shop.CakeShopMapParam;
+import com.cakk.domain.mysql.dto.param.shop.CakeShopParam;
 import com.cakk.domain.mysql.dto.param.shop.CakeShopSimpleParam;
 import com.cakk.domain.mysql.entity.shop.CakeShop;
 import com.cakk.domain.mysql.entity.shop.CakeShopOperation;
@@ -105,7 +107,21 @@ public class ShopMapper {
 		return cakeShops.stream().map(CakeShop::getId).collect(Collectors.toList());
 	}
 
-	public static CakeShopByMapResponse supplyCakeShopByMapResponseBy(List<CakeShopMapParam> params) {
+	public static List<Long> supplyCakeShopIdsByCakeShopParams(List<CakeShopByKeywordParam> cakeShops) {
+		return cakeShops.stream().map(CakeShopByKeywordParam::cakeShopId).collect(Collectors.toList());
+	}
+
+	public static CakeShopByMapResponse supplyCakeShopByMapResponseBy(List<CakeShopParam> params) {
 		return new CakeShopByMapResponse(params);
+	}
+
+	public static CakeShopSearchResponse supplyCakeShopSearchResponseBy(List<CakeShopParam> cakeShops) {
+		final int size = cakeShops.size();
+
+		return CakeShopSearchResponse.builder()
+			.cakeShops(cakeShops)
+			.lastCakeShopId(cakeShops.isEmpty() ? null : cakeShops.get(size - 1).getCakeShopId())
+			.size(cakeShops.size())
+			.build();
 	}
 }

--- a/cakk-api/src/main/java/com/cakk/api/service/shop/ShopService.java
+++ b/cakk-api/src/main/java/com/cakk/api/service/shop/ShopService.java
@@ -9,7 +9,6 @@ import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 
 import com.cakk.api.dto.request.shop.CreateShopRequest;
-import com.cakk.api.dto.request.shop.OperationDayRequest;
 import com.cakk.api.dto.request.shop.PromotionRequest;
 import com.cakk.api.dto.request.shop.SearchShopByLocationRequest;
 import com.cakk.api.dto.response.shop.CakeShopByMapResponse;
@@ -18,6 +17,7 @@ import com.cakk.api.dto.response.shop.CakeShopInfoResponse;
 import com.cakk.api.dto.response.shop.CakeShopSimpleResponse;
 import com.cakk.api.mapper.PointMapper;
 import com.cakk.api.mapper.ShopMapper;
+import com.cakk.common.dto.OperationDays;
 import com.cakk.domain.mysql.bo.CakeShopByMaps;
 import com.cakk.domain.mysql.dto.param.cake.CakeImageResponseParam;
 import com.cakk.domain.mysql.dto.param.shop.CakeShopDetailParam;
@@ -46,15 +46,15 @@ public class ShopService {
 
 	@Transactional
 	public void createCakeShopByCertification(CreateShopRequest request) {
-		final OperationDayRequest operationDayRequest = request.operationDayRequest();
+		final OperationDays operationDays = request.operationDays();
 		CakeShop cakeShop = ShopMapper.supplyCakeShopBy(request);
 		BusinessInformation businessInformation = ShopMapper.supplyBusinessInformationBy(request, cakeShop);
 		List<CakeShopOperation> cakeShopOperations = ShopMapper
 			.supplyCakeShopOperationsBy(
 				cakeShop,
-				operationDayRequest.days(),
-				operationDayRequest.startTimes(),
-				operationDayRequest.endTimes()
+				operationDays.days(),
+				operationDays.startTimes(),
+				operationDays.endTimes()
 			);
 
 		cakeShopWriter.createCakeShop(cakeShop, cakeShopOperations, businessInformation);

--- a/cakk-api/src/main/java/com/cakk/api/service/shop/ShopService.java
+++ b/cakk-api/src/main/java/com/cakk/api/service/shop/ShopService.java
@@ -8,21 +8,25 @@ import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 
+import com.cakk.api.dto.request.shop.CakeShopSearchRequest;
 import com.cakk.api.dto.request.shop.CreateShopRequest;
 import com.cakk.api.dto.request.shop.PromotionRequest;
 import com.cakk.api.dto.request.shop.SearchShopByLocationRequest;
 import com.cakk.api.dto.response.shop.CakeShopByMapResponse;
 import com.cakk.api.dto.response.shop.CakeShopDetailResponse;
 import com.cakk.api.dto.response.shop.CakeShopInfoResponse;
+import com.cakk.api.dto.response.shop.CakeShopSearchResponse;
 import com.cakk.api.dto.response.shop.CakeShopSimpleResponse;
 import com.cakk.api.mapper.PointMapper;
 import com.cakk.api.mapper.ShopMapper;
 import com.cakk.common.dto.OperationDays;
 import com.cakk.domain.mysql.bo.CakeShops;
 import com.cakk.domain.mysql.dto.param.cake.CakeImageResponseParam;
+import com.cakk.domain.mysql.dto.param.shop.CakeShopByKeywordParam;
 import com.cakk.domain.mysql.dto.param.shop.CakeShopDetailParam;
 import com.cakk.domain.mysql.dto.param.shop.CakeShopInfoParam;
 import com.cakk.domain.mysql.dto.param.shop.CakeShopSimpleParam;
+import com.cakk.domain.mysql.dto.param.shop.ShopOperationParam;
 import com.cakk.domain.mysql.dto.param.user.CertificationParam;
 import com.cakk.domain.mysql.entity.shop.CakeShop;
 import com.cakk.domain.mysql.entity.shop.CakeShopOperation;
@@ -117,5 +121,20 @@ public class ShopService {
 		final CakeShops cakeShopsByMap = new CakeShops(cakeShops, cakes);
 
 		return ShopMapper.supplyCakeShopByMapResponseBy(cakeShopsByMap.getCakeShops());
+	}
+
+	@Transactional(readOnly = true)
+	public CakeShopSearchResponse searchShopByKeyword(CakeShopSearchRequest dto) {
+		final List<CakeShopByKeywordParam> cakeShops = cakeShopReader.searchShopByKeyword(dto.toParam());
+		final List<ShopOperationParam> cakeShopOperations = cakeShopOperationReader.searchShopOperationsByCakeShops(
+			ShopMapper.supplyCakeShopIdsByCakeShopParams(cakeShops)
+		);
+		final List<CakeImageResponseParam> cakeImages = cakeReader.searchCakeImagesByCakeShops(
+			ShopMapper.supplyCakeShopIdsByCakeShopParams(cakeShops)
+		);
+
+		final CakeShops cakeShopsByKeyword = new CakeShops(cakeShops, cakeShopOperations, cakeImages);
+
+		return ShopMapper.supplyCakeShopSearchResponseBy(cakeShopsByKeyword.getCakeShops());
 	}
 }

--- a/cakk-api/src/main/java/com/cakk/api/service/shop/ShopService.java
+++ b/cakk-api/src/main/java/com/cakk/api/service/shop/ShopService.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 
 import com.cakk.api.dto.request.shop.CakeShopSearchRequest;
 import com.cakk.api.dto.request.shop.CreateShopRequest;
+import com.cakk.api.dto.request.shop.OperationDays;
 import com.cakk.api.dto.request.shop.PromotionRequest;
 import com.cakk.api.dto.request.shop.SearchShopByLocationRequest;
 import com.cakk.api.dto.response.shop.CakeShopByMapResponse;
@@ -19,7 +20,6 @@ import com.cakk.api.dto.response.shop.CakeShopSearchResponse;
 import com.cakk.api.dto.response.shop.CakeShopSimpleResponse;
 import com.cakk.api.mapper.PointMapper;
 import com.cakk.api.mapper.ShopMapper;
-import com.cakk.api.dto.request.shop.OperationDays;
 import com.cakk.domain.mysql.bo.CakeShops;
 import com.cakk.domain.mysql.dto.param.cake.CakeImageResponseParam;
 import com.cakk.domain.mysql.dto.param.shop.CakeShopByKeywordParam;

--- a/cakk-api/src/main/java/com/cakk/api/service/shop/ShopService.java
+++ b/cakk-api/src/main/java/com/cakk/api/service/shop/ShopService.java
@@ -19,7 +19,7 @@ import com.cakk.api.dto.response.shop.CakeShopSearchResponse;
 import com.cakk.api.dto.response.shop.CakeShopSimpleResponse;
 import com.cakk.api.mapper.PointMapper;
 import com.cakk.api.mapper.ShopMapper;
-import com.cakk.common.dto.OperationDays;
+import com.cakk.api.dto.request.shop.OperationDays;
 import com.cakk.domain.mysql.bo.CakeShops;
 import com.cakk.domain.mysql.dto.param.cake.CakeImageResponseParam;
 import com.cakk.domain.mysql.dto.param.shop.CakeShopByKeywordParam;

--- a/cakk-api/src/main/java/com/cakk/api/service/shop/ShopService.java
+++ b/cakk-api/src/main/java/com/cakk/api/service/shop/ShopService.java
@@ -18,7 +18,7 @@ import com.cakk.api.dto.response.shop.CakeShopSimpleResponse;
 import com.cakk.api.mapper.PointMapper;
 import com.cakk.api.mapper.ShopMapper;
 import com.cakk.common.dto.OperationDays;
-import com.cakk.domain.mysql.bo.CakeShopByMaps;
+import com.cakk.domain.mysql.bo.CakeShops;
 import com.cakk.domain.mysql.dto.param.cake.CakeImageResponseParam;
 import com.cakk.domain.mysql.dto.param.shop.CakeShopDetailParam;
 import com.cakk.domain.mysql.dto.param.shop.CakeShopInfoParam;
@@ -30,6 +30,7 @@ import com.cakk.domain.mysql.entity.user.BusinessInformation;
 import com.cakk.domain.mysql.entity.user.User;
 import com.cakk.domain.mysql.event.shop.CertificationEvent;
 import com.cakk.domain.mysql.repository.reader.CakeReader;
+import com.cakk.domain.mysql.repository.reader.CakeShopOperationReader;
 import com.cakk.domain.mysql.repository.reader.CakeShopReader;
 import com.cakk.domain.mysql.repository.reader.UserReader;
 import com.cakk.domain.mysql.repository.writer.CakeShopWriter;
@@ -42,6 +43,7 @@ public class ShopService {
 	private final CakeShopReader cakeShopReader;
 	private final CakeShopWriter cakeShopWriter;
 	private final CakeReader cakeReader;
+	private final CakeShopOperationReader cakeShopOperationReader;
 	private final ApplicationEventPublisher publisher;
 
 	@Transactional
@@ -112,8 +114,8 @@ public class ShopService {
 		List<CakeShop> cakeShops = cakeShopReader.searchShopByLocationBased(PointMapper.supplyPointBy(latitude, longitude));
 		List<CakeImageResponseParam> cakes = cakeReader.searchCakeImagesByCakeShops(ShopMapper.supplyCakeShopIdsBy(cakeShops));
 
-		final CakeShopByMaps cakeShopByMaps = new CakeShopByMaps(cakeShops, cakes);
+		final CakeShops cakeShopsByMap = new CakeShops(cakeShops, cakes);
 
-		return ShopMapper.supplyCakeShopByMapResponseBy(cakeShopByMaps.getCakeShopByMaps());
+		return ShopMapper.supplyCakeShopByMapResponseBy(cakeShopsByMap.getCakeShops());
 	}
 }

--- a/cakk-api/src/main/java/com/cakk/api/validator/OperationValidator.java
+++ b/cakk-api/src/main/java/com/cakk/api/validator/OperationValidator.java
@@ -4,7 +4,7 @@ import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 
 import com.cakk.api.annotation.OperationDay;
-import com.cakk.common.dto.OperationDays;
+import com.cakk.api.dto.request.shop.OperationDays;
 
 public class OperationValidator implements ConstraintValidator<OperationDay, OperationDays> {
 

--- a/cakk-api/src/main/java/com/cakk/api/validator/OperationValidator.java
+++ b/cakk-api/src/main/java/com/cakk/api/validator/OperationValidator.java
@@ -4,12 +4,12 @@ import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 
 import com.cakk.api.annotation.OperationDay;
-import com.cakk.api.dto.request.shop.OperationDayRequest;
+import com.cakk.common.dto.OperationDays;
 
-public class OperationValidator implements ConstraintValidator<OperationDay, OperationDayRequest> {
+public class OperationValidator implements ConstraintValidator<OperationDay, OperationDays> {
 
 	@Override
-	public boolean isValid(OperationDayRequest value, ConstraintValidatorContext context) {
+	public boolean isValid(OperationDays value, ConstraintValidatorContext context) {
 		if (value.days().size() != value.startTimes().size()) {
 			return false;
 		} else if (value.days().size() != value.endTimes().size()) {

--- a/cakk-api/src/main/java/com/cakk/api/validator/OperationValidator.java
+++ b/cakk-api/src/main/java/com/cakk/api/validator/OperationValidator.java
@@ -3,10 +3,10 @@ package com.cakk.api.validator;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 
-import com.cakk.api.annotation.OperationDays;
+import com.cakk.api.annotation.OperationDay;
 import com.cakk.api.dto.request.shop.OperationDayRequest;
 
-public class OperationValidator implements ConstraintValidator<OperationDays, OperationDayRequest> {
+public class OperationValidator implements ConstraintValidator<OperationDay, OperationDayRequest> {
 
 	@Override
 	public boolean isValid(OperationDayRequest value, ConstraintValidatorContext context) {

--- a/cakk-api/src/test/java/com/cakk/api/integration/cake/CakeIntegrationTest.java
+++ b/cakk-api/src/test/java/com/cakk/api/integration/cake/CakeIntegrationTest.java
@@ -212,12 +212,11 @@ class CakeIntegrationTest extends IntegrationTest {
 		assertEquals(0, data.size());
 	}
 
-	@TestWithDisplayName("검색어, 태그명, 케이크 카테고리, 사용자 위치를 포함한 동적 검색, SQL 파일 기준 10개가 조회된다")
+	@TestWithDisplayName("검색어, 태그명, 케이크 카테고리, 사용자 위치를 포함한 동적 검색, SQL 파일 기준 3개가 조회된다")
 	void searchCakeImagesByTextAndLocation1() {
 		final String url = "%s%d%s/search/cakes".formatted(BASE_URL, port, API_URL);
 		final UriComponents uriComponents = UriComponentsBuilder
 			.fromUriString(url)
-			.queryParam("cakeId", 0)
 			.queryParam("keyword", "케")
 			.queryParam("latitude", 37.2096575)
 			.queryParam("longitude", 127.0998228)
@@ -234,11 +233,33 @@ class CakeIntegrationTest extends IntegrationTest {
 		assertEquals(HttpStatusCode.valueOf(200), responseEntity.getStatusCode());
 		assertEquals(ReturnCode.SUCCESS.getCode(), response.getReturnCode());
 		assertEquals(ReturnCode.SUCCESS.getMessage(), response.getReturnMessage());
-		assertEquals(10, data.size());
 	}
 
-	@TestWithDisplayName("사용자 위치를 포함한 동적 검색, SQL 파일 기준 10개가 조회된다")
+	@TestWithDisplayName("검색어, 태그명, 케이크 카테고리, 사용자 위치를 포함한 동적 검색, SQL 파일 기준 7개가 조회된다")
 	void searchCakeImagesByTextAndLocation2() {
+		final String url = "%s%d%s/search/cakes".formatted(BASE_URL, port, API_URL);
+		final UriComponents uriComponents = UriComponentsBuilder
+			.fromUriString(url)
+			.queryParam("keyword", "케")
+			.queryParam("latitude", 37.543343)
+			.queryParam("longitude", 127.052609)
+			.queryParam("pageSize", 10)
+			.build();
+
+		// when
+		final ResponseEntity<ApiResponse> responseEntity = restTemplate.getForEntity(uriComponents.toUriString(), ApiResponse.class);
+
+		// then
+		final ApiResponse response = objectMapper.convertValue(responseEntity.getBody(), ApiResponse.class);
+		final CakeImageListResponse data = objectMapper.convertValue(response.getData(), CakeImageListResponse.class);
+
+		assertEquals(HttpStatusCode.valueOf(200), responseEntity.getStatusCode());
+		assertEquals(ReturnCode.SUCCESS.getCode(), response.getReturnCode());
+		assertEquals(ReturnCode.SUCCESS.getMessage(), response.getReturnMessage());
+	}
+
+	@TestWithDisplayName("사용자 위치를 포함한 동적 검색, SQL 파일 기준 3개가 조회된다")
+	void searchCakeImagesByTextAndLocation3() {
 		final String url = "%s%d%s/search/cakes".formatted(BASE_URL, port, API_URL);
 		final UriComponents uriComponents = UriComponentsBuilder
 			.fromUriString(url)
@@ -257,7 +278,6 @@ class CakeIntegrationTest extends IntegrationTest {
 		assertEquals(HttpStatusCode.valueOf(200), responseEntity.getStatusCode());
 		assertEquals(ReturnCode.SUCCESS.getCode(), response.getReturnCode());
 		assertEquals(ReturnCode.SUCCESS.getMessage(), response.getReturnMessage());
-		assertEquals(10, data.size());
 	}
 
 	@TestWithDisplayName("해당 id의 케이크 좋아요에 성공한다.")

--- a/cakk-api/src/test/java/com/cakk/api/integration/shop/ShopIntegrationTest.java
+++ b/cakk-api/src/test/java/com/cakk/api/integration/shop/ShopIntegrationTest.java
@@ -375,12 +375,14 @@ class ShopIntegrationTest extends IntegrationTest {
 		});
 	}
 
-	@TestWithDisplayName("테스트 sql script 기준 10개의 케이크 샵이 조회된다")
+	@TestWithDisplayName("테스트 sql script 기준 7개의 케이크 샵이 조회된다")
 	void searchCakeShopsByKeywordsWithConditions1() {
 		final String url = "%s%d%s/search/shops".formatted(BASE_URL, port, API_URL);
 		final UriComponents uriComponents = UriComponentsBuilder
 			.fromUriString(url)
-			.queryParam("keyword", "케이크")
+			.queryParam("cakeShopId", 11L)
+			.queryParam("latitude", 37.543343)
+			.queryParam("longitude", 127.052609)
 			.queryParam("pageSize", 10)
 			.build();
 
@@ -395,7 +397,7 @@ class ShopIntegrationTest extends IntegrationTest {
 		assertEquals(ReturnCode.SUCCESS.getCode(), response.getReturnCode());
 		assertEquals(ReturnCode.SUCCESS.getMessage(), response.getReturnMessage());
 
-		assertEquals(10, data.size());
+		assertEquals(7, data.size());
 		data.cakeShops().forEach(cakeShop -> {
 			assertThat(cakeShop.getCakeImageUrls().size()).isLessThanOrEqualTo(4);
 			assertThat(cakeShop.getCakeShopId()).isNotNull();
@@ -404,7 +406,7 @@ class ShopIntegrationTest extends IntegrationTest {
 		});
 	}
 
-	@TestWithDisplayName("테스트 sql script를 기준 10개의 케이크샵이 조회된다")
+	@TestWithDisplayName("테스트 sql script를 기준 3개의 케이크샵이 조회된다")
 	void searchCakeShopsByKeywordWithConditions2() {
 		final String url = "%s%d%s/search/shops".formatted(BASE_URL, port, API_URL);
 		final UriComponents uriComponents = UriComponentsBuilder
@@ -426,7 +428,7 @@ class ShopIntegrationTest extends IntegrationTest {
 		assertEquals(ReturnCode.SUCCESS.getCode(), response.getReturnCode());
 		assertEquals(ReturnCode.SUCCESS.getMessage(), response.getReturnMessage());
 
-		assertEquals(10, data.size());
+		assertEquals(3, data.size());
 		data.cakeShops().forEach(cakeShop -> {
 			assertThat(cakeShop.getCakeImageUrls().size()).isLessThanOrEqualTo(4);
 			assertThat(cakeShop.getCakeShopId()).isNotNull();

--- a/cakk-api/src/test/java/com/cakk/api/integration/shop/ShopIntegrationTest.java
+++ b/cakk-api/src/test/java/com/cakk/api/integration/shop/ShopIntegrationTest.java
@@ -26,6 +26,7 @@ import com.cakk.api.dto.request.user.CertificationRequest;
 import com.cakk.api.dto.response.shop.CakeShopByMapResponse;
 import com.cakk.api.dto.response.shop.CakeShopDetailResponse;
 import com.cakk.api.dto.response.shop.CakeShopInfoResponse;
+import com.cakk.api.dto.response.shop.CakeShopSearchResponse;
 import com.cakk.api.dto.response.shop.CakeShopSimpleResponse;
 import com.cakk.common.enums.Days;
 import com.cakk.common.enums.ReturnCode;
@@ -266,7 +267,7 @@ class ShopIntegrationTest extends IntegrationTest {
 		assertEquals(ReturnCode.NOT_EXIST_CAKE_SHOP.getMessage(), response.getReturnMessage());
 	}
 
-	@TestWithDisplayName("테스트 sql script를 기준으로 사용자 위치를 중심으로 반경 5km 이내의 가게들을 조회한다")
+	@TestWithDisplayName("테스트 sql script 기준으로 사용자 위치를 중심으로 반경 5km 이내의 가게들을 조회한다")
 	void findAllShopsByLocationBased1() {
 		final String url = "%s%d%s".formatted(BASE_URL, port, API_URL);
 		final UriComponents uriComponents = UriComponentsBuilder
@@ -287,6 +288,7 @@ class ShopIntegrationTest extends IntegrationTest {
 		assertEquals(ReturnCode.SUCCESS.getCode(), response.getReturnCode());
 		assertEquals(ReturnCode.SUCCESS.getMessage(), response.getReturnMessage());
 
+		assertEquals(3, data.cakeShops().size());
 		data.cakeShops().forEach(cakeShop -> {
 			assertThat(cakeShop.getCakeShopId()).isIn(1L, 2L, 3L);
 			assertThat(cakeShop.getCakeImageUrls().size()).isLessThanOrEqualTo(4);
@@ -342,5 +344,94 @@ class ShopIntegrationTest extends IntegrationTest {
 		assertEquals(ReturnCode.SUCCESS.getCode(), response.getReturnCode());
 		assertEquals(ReturnCode.SUCCESS.getMessage(), response.getReturnMessage());
 		assertNull(response.getData());
+	}
+
+	@TestWithDisplayName("테스트 sql script 기준으로 사용자 위치를 중심으로 반경 5km 이내의 가게들을 조회한다")
+	void findAllShopsByLocationBased2() {
+		final String url = "%s%d%s".formatted(BASE_URL, port, API_URL);
+		final UriComponents uriComponents = UriComponentsBuilder
+			.fromUriString(url)
+			.path("/location-based")
+			.queryParam("latitude", 37.543343)
+			.queryParam("longitude", 127.052609)
+			.build();
+
+		//when
+		final ResponseEntity<ApiResponse> responseEntity = restTemplate.getForEntity(uriComponents.toUriString(), ApiResponse.class);
+
+		//then
+		final ApiResponse response = objectMapper.convertValue(responseEntity.getBody(), ApiResponse.class);
+		final CakeShopByMapResponse data = objectMapper.convertValue(response.getData(), CakeShopByMapResponse.class);
+
+		assertEquals(HttpStatusCode.valueOf(200), responseEntity.getStatusCode());
+		assertEquals(ReturnCode.SUCCESS.getCode(), response.getReturnCode());
+		assertEquals(ReturnCode.SUCCESS.getMessage(), response.getReturnMessage());
+
+		assertEquals(7, data.cakeShops().size());
+		data.cakeShops().forEach(cakeShop -> {
+			assertThat(cakeShop.getCakeShopId()).isIn(4L, 5L, 6L, 7L, 8L, 9L, 10L);
+			assertThat(cakeShop.getCakeImageUrls().size()).isLessThanOrEqualTo(4);
+			assertThat(cakeShop.getCakeShopName()).isNotNull();
+		});
+	}
+
+	@TestWithDisplayName("테스트 sql script 기준 10개의 케이크 샵이 조회된다")
+	void searchCakeShopsByKeywordsWithConditions1() {
+		final String url = "%s%d%s/search/shops".formatted(BASE_URL, port, API_URL);
+		final UriComponents uriComponents = UriComponentsBuilder
+			.fromUriString(url)
+			.queryParam("keyword", "케이크")
+			.queryParam("pageSize", 10)
+			.build();
+
+		//when
+		final ResponseEntity<ApiResponse> responseEntity = restTemplate.getForEntity(uriComponents.toUriString(), ApiResponse.class);
+
+		//then
+		final ApiResponse response = objectMapper.convertValue(responseEntity.getBody(), ApiResponse.class);
+		final CakeShopSearchResponse data = objectMapper.convertValue(response.getData(), CakeShopSearchResponse.class);
+
+		assertEquals(HttpStatusCode.valueOf(200), responseEntity.getStatusCode());
+		assertEquals(ReturnCode.SUCCESS.getCode(), response.getReturnCode());
+		assertEquals(ReturnCode.SUCCESS.getMessage(), response.getReturnMessage());
+
+		assertEquals(10, data.size());
+		data.cakeShops().forEach(cakeShop -> {
+			assertThat(cakeShop.getCakeImageUrls().size()).isLessThanOrEqualTo(4);
+			assertThat(cakeShop.getCakeShopId()).isNotNull();
+			assertThat(cakeShop.getCakeShopName()).isNotNull();
+			assertThat(cakeShop.getOperationDays()).isNotNull();
+		});
+	}
+
+	@TestWithDisplayName("테스트 sql script를 기준 10개의 케이크샵이 조회된다")
+	void searchCakeShopsByKeywordWithConditions2() {
+		final String url = "%s%d%s/search/shops".formatted(BASE_URL, port, API_URL);
+		final UriComponents uriComponents = UriComponentsBuilder
+			.fromUriString(url)
+			.queryParam("keyword", "케이크")
+			.queryParam("latitude", 37.2096575)
+			.queryParam("longitude", 127.0998228)
+			.queryParam("pageSize", 10)
+			.build();
+
+		//when
+		final ResponseEntity<ApiResponse> responseEntity = restTemplate.getForEntity(uriComponents.toUriString(), ApiResponse.class);
+
+		//then
+		final ApiResponse response = objectMapper.convertValue(responseEntity.getBody(), ApiResponse.class);
+		final CakeShopSearchResponse data = objectMapper.convertValue(response.getData(), CakeShopSearchResponse.class);
+
+		assertEquals(HttpStatusCode.valueOf(200), responseEntity.getStatusCode());
+		assertEquals(ReturnCode.SUCCESS.getCode(), response.getReturnCode());
+		assertEquals(ReturnCode.SUCCESS.getMessage(), response.getReturnMessage());
+
+		assertEquals(10, data.size());
+		data.cakeShops().forEach(cakeShop -> {
+			assertThat(cakeShop.getCakeImageUrls().size()).isLessThanOrEqualTo(4);
+			assertThat(cakeShop.getCakeShopId()).isNotNull();
+			assertThat(cakeShop.getCakeShopName()).isNotNull();
+			assertThat(cakeShop.getOperationDays()).isNotNull();
+		});
 	}
 }

--- a/cakk-api/src/test/java/com/cakk/api/service/shop/ShopServiceTest.java
+++ b/cakk-api/src/test/java/com/cakk/api/service/shop/ShopServiceTest.java
@@ -24,7 +24,7 @@ import com.cakk.api.dto.response.shop.CakeShopInfoResponse;
 import com.cakk.api.dto.response.shop.CakeShopSimpleResponse;
 import com.cakk.api.mapper.PointMapper;
 import com.cakk.api.mapper.ShopMapper;
-import com.cakk.common.dto.OperationDays;
+import com.cakk.api.dto.request.shop.OperationDays;
 import com.cakk.common.enums.Days;
 import com.cakk.common.enums.ReturnCode;
 import com.cakk.common.exception.CakkException;

--- a/cakk-api/src/test/java/com/cakk/api/service/shop/ShopServiceTest.java
+++ b/cakk-api/src/test/java/com/cakk/api/service/shop/ShopServiceTest.java
@@ -18,13 +18,13 @@ import net.jqwik.api.Arbitraries;
 import com.cakk.api.common.annotation.TestWithDisplayName;
 import com.cakk.api.common.base.ServiceTest;
 import com.cakk.api.dto.request.shop.CreateShopRequest;
-import com.cakk.api.dto.request.shop.OperationDayRequest;
 import com.cakk.api.dto.request.shop.PromotionRequest;
 import com.cakk.api.dto.response.shop.CakeShopDetailResponse;
 import com.cakk.api.dto.response.shop.CakeShopInfoResponse;
 import com.cakk.api.dto.response.shop.CakeShopSimpleResponse;
 import com.cakk.api.mapper.PointMapper;
 import com.cakk.api.mapper.ShopMapper;
+import com.cakk.common.dto.OperationDays;
 import com.cakk.common.enums.Days;
 import com.cakk.common.enums.ReturnCode;
 import com.cakk.common.exception.CakkException;
@@ -60,8 +60,8 @@ public class ShopServiceTest extends ServiceTest {
 	@Mock
 	private ApplicationEventPublisher publisher;
 
-	private OperationDayRequest getOperationDayFixture() {
-		return getConstructorMonkey().giveMeBuilder(OperationDayRequest.class)
+	private OperationDays getOperationDayFixture() {
+		return getConstructorMonkey().giveMeBuilder(OperationDays.class)
 			.set("days", Arbitraries.of(Days.class).list().ofSize(7))
 			.set("startTimes",
 				Arbitraries.of(
@@ -78,7 +78,7 @@ public class ShopServiceTest extends ServiceTest {
 	private CreateShopRequest getCreateShopRequestFixture() {
 		return getConstructorMonkey().giveMeBuilder(CreateShopRequest.class)
 			.set("businessNumber", Arbitraries.strings().withCharRange('a', 'z').ofMinLength(1).ofMaxLength(7))
-			.set("operationDayRequest", getOperationDayFixture())
+			.set("operationDays", getOperationDayFixture())
 			.set("shopName", Arbitraries.strings().withCharRange('a', 'z').ofMinLength(1).ofMaxLength(20))
 			.set("shopBio", Arbitraries.strings().withCharRange('a', 'z').ofMaxLength(20))
 			.set("shopDescription", Arbitraries.strings().withCharRange('a', 'z').ofMaxLength(20))

--- a/cakk-api/src/test/resources/sql/insert-cake-shop.sql
+++ b/cakk-api/src/test/resources/sql/insert-cake-shop.sql
@@ -1,12 +1,26 @@
 SET @g1 = 'Point(37.197734 127.098190)';
 SET @g2 = 'Point(37.201623 127.091568)';
 SET @g3 = 'Point(37.209769 127.100107)';
+SET @g4 = 'Point(37.541530 127.054164)';
+SET @g5 = 'Point(37.543343 127.052609)';
+SET @g6 = 'Point(37.541530 127.054164)';
+SET @g7 = 'Point(37.543343 127.052609)';
+SET @g8 = 'Point(37.541530 127.054164)';
+SET @g9 = 'Point(37.543343 127.052609)';
+SET @g10 = 'Point(37.541530 127.054164)';
 
 insert into cake_shop (shop_id, thumbnail_url, shop_name, shop_address, shop_bio, shop_description, location, like_count, linked_flag,
                        created_at, updated_at)
 values (1, 'thumbnail_url1', '케이크 맛집1', '케이크 맛집입니다.', '서울시 강남구 어쩌고로1', '케이크 맛집입니다.', ST_GeomFromText(@g1, 4326), 0, false, now(), now()),
        (2, 'thumbnail_url2', '케이크 맛집2', '케이크 맛집입니다.', '서울시 강남구 어쩌고로2', '케이크 맛집입니다.', ST_GeomFromText(@g2, 4326), 0, false, now(), now()),
-       (3, 'thumbnail_url3', '케이크 맛집3', '케이크 맛집입니다.', '서울시 강남구 어쩌고로3', '케이크 맛집입니다.', ST_GeomFromText(@g3, 4326), 0, false, now(), now());
+       (3, 'thumbnail_url3', '케이크 맛집3', '케이크 맛집입니다.', '서울시 강남구 어쩌고로3', '케이크 맛집입니다.', ST_GeomFromText(@g3, 4326), 0, false, now(), now()),
+       (4, 'thumbnail_url4', '케이크 맛집4', '케이크 맛집입니다.', '서울시 강남구 어쩌고로3', '케이크 맛집입니다.', ST_GeomFromText(@g4, 4326), 0, false, now(), now()),
+       (5, 'thumbnail_url5', '케이크 맛집5', '케이크 맛집입니다.', '서울시 강남구 어쩌고로3', '케이크 맛집입니다.', ST_GeomFromText(@g5, 4326), 0, false, now(), now()),
+       (6, 'thumbnail_url6', '케이크 맛집6', '케이크 맛집입니다.', '서울시 강남구 어쩌고로3', '케이크 맛집입니다.', ST_GeomFromText(@g6, 4326), 0, false, now(), now()),
+       (7, 'thumbnail_url7', '케이크 맛집7', '케이크 맛집입니다.', '서울시 강남구 어쩌고로3', '케이크 맛집입니다.', ST_GeomFromText(@g7, 4326), 0, false, now(), now()),
+       (8, 'thumbnail_url8', '케이크 맛집8', '케이크 맛집입니다.', '서울시 강남구 어쩌고로3', '케이크 맛집입니다.', ST_GeomFromText(@g8, 4326), 0, false, now(), now()),
+       (9, 'thumbnail_url9', '케이크 맛집9', '케이크 맛집입니다.', '서울시 강남구 어쩌고로3', '케이크 맛집입니다.', ST_GeomFromText(@g9, 4326), 0, false, now(), now()),
+       (10, 'thumbnail_url10', '케이크 맛집10', '케이크 맛집입니다.', '서울시 강남구 어쩌고로3', '케이크 맛집입니다.', ST_GeomFromText(@g10, 4326), 0, false, now(), now());
 
 insert into cake (cake_id, shop_id, cake_image_url, like_count, created_at, updated_at)
 values (1, 1, 'cake_image_url1', 0, now(), now()),
@@ -18,7 +32,31 @@ values (1, 1, 'cake_image_url1', 0, now(), now()),
        (7, 3, 'cake_image_url7', 0, now(), now()),
        (8, 3, 'cake_image_url8', 0, now(), now()),
        (9, 3, 'cake_image_url9', 0, now(), now()),
-       (10, 3, 'cake_image_url10', 0, now(), now());
+       (10, 3, 'cake_image_url10', 0, now(), now()),
+       (11, 3, 'cake_image_url11', 0, now(), now()),
+       (12, 4, 'cake_image_url12', 0, now(), now()),
+       (13, 4, 'cake_image_url13', 0, now(), now()),
+       (14, 4, 'cake_image_url14', 0, now(), now()),
+       (15, 5, 'cake_image_url15', 0, now(), now()),
+       (16, 5, 'cake_image_url16', 0, now(), now()),
+       (17, 5, 'cake_image_url17', 0, now(), now()),
+       (18, 5, 'cake_image_url18', 0, now(), now()),
+       (19, 5, 'cake_image_url19', 0, now(), now()),
+       (20, 6, 'cake_image_url20', 0, now(), now()),
+       (21, 6, 'cake_image_url21', 0, now(), now()),
+       (22, 6, 'cake_image_url22', 0, now(), now()),
+       (23, 7, 'cake_image_url23', 0, now(), now()),
+       (24, 7, 'cake_image_url24', 0, now(), now()),
+       (25, 7, 'cake_image_url25', 0, now(), now()),
+       (26, 8, 'cake_image_url26', 0, now(), now()),
+       (27, 8, 'cake_image_url27', 0, now(), now()),
+       (28, 8, 'cake_image_url28', 0, now(), now()),
+       (29, 9, 'cake_image_url29', 0, now(), now()),
+       (30, 10, 'cake_image_url30', 0, now(), now()),
+       (31, 10, 'cake_image_url31', 0, now(), now()),
+       (32, 10, 'cake_image_url32', 0, now(), now()),
+       (33, 10, 'cake_image_url33', 0, now(), now()),
+       (34, 10, 'cake_image_url34', 0, now(), now());
 
 insert into cake_shop_operation (operation_id, shop_id, operation_day, start_time, end_time, created_at, updated_at)
 values (1, 1, 0, '10:00:00', '22:00:00', now(), now()),
@@ -30,7 +68,13 @@ values (1, 1, 0, '10:00:00', '22:00:00', now(), now()),
        (7, 2, 2, '8:00:00', '21:00:00', now(), now()),
        (8, 2, 4, '8:00:00', '21:00:00', now(), now()),
        (9, 3, 5, '7:00:00', '19:00:00', now(), now()),
-       (10, 3, 6, '7:00:00', '19:00:00', now(), now());
+       (10, 4, 6, '7:00:00', '19:00:00', now(), now()),
+       (11, 5, 6, '7:00:00', '19:00:00', now(), now()),
+       (12, 6, 6, '7:00:00', '19:00:00', now(), now()),
+       (13, 7, 6, '7:00:00', '19:00:00', now(), now()),
+       (14, 8, 6, '7:00:00', '19:00:00', now(), now()),
+       (15, 9, 6, '7:00:00', '19:00:00', now(), now()),
+       (16, 10, 6, '7:00:00', '19:00:00', now(), now());
 
 insert into cake_shop_link (link_id, shop_id, link_kind, link_path, created_at, updated_at)
 values (1, 1, 'web', 'https://www.cake-shop1.com', now(), now()),

--- a/cakk-common/src/main/java/com/cakk/common/dto/OperationDays.java
+++ b/cakk-common/src/main/java/com/cakk/common/dto/OperationDays.java
@@ -1,19 +1,14 @@
-package com.cakk.api.dto.request.shop;
+package com.cakk.common.dto;
 
 import java.time.LocalTime;
 import java.util.List;
 
-import jakarta.validation.constraints.NotNull;
-
 import com.cakk.common.enums.Days;
 
-public record OperationDayRequest(
+public record OperationDays(
 
-	@NotNull
 	List<Days> days,
-	@NotNull
 	List<LocalTime> startTimes,
-	@NotNull
 	List<LocalTime> endTimes
 ) {
 }

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/bo/CakeShops.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/bo/CakeShops.java
@@ -10,40 +10,41 @@ import java.util.Objects;
 import com.cakk.common.enums.ReturnCode;
 import com.cakk.common.exception.CakkException;
 import com.cakk.domain.mysql.dto.param.cake.CakeImageResponseParam;
-import com.cakk.domain.mysql.dto.param.shop.CakeShopMapParam;
+import com.cakk.domain.mysql.dto.param.shop.CakeShopParam;
 import com.cakk.domain.mysql.entity.shop.CakeShop;
 
-public class CakeShopByMaps {
+public class CakeShops {
 
-	private List<CakeShopMapParam> cakeShopByMaps;
+	private List<CakeShopParam> cakeShops;
 
-	public CakeShopByMaps(List<CakeShop> cakeShops, List<CakeImageResponseParam> cakes) {
-		cakeShopByMaps = new ArrayList<>();
-		initCakeShopByMaps(cakeShops);
+	public CakeShops(List<CakeShop> cakeShops, List<CakeImageResponseParam> cakes) {
+		this.cakeShops = new ArrayList<>();
+		initCakeShopByLocationBased(cakeShops);
 		matchRepresentCakeImagesByMaxFour(cakes);
 	}
 
-	public List<CakeShopMapParam> getCakeShopByMaps() {
-		return cakeShopByMaps;
+	public List<CakeShopParam> getCakeShops() {
+		return cakeShops;
 	}
 
-	private void initCakeShopByMaps(List<CakeShop> cakeShops) {
-		cakeShops.forEach(cakeShop -> cakeShopByMaps.add(
-			CakeShopMapParam.builder()
+	private void initCakeShopByLocationBased(List<CakeShop> cakeShops) {
+		cakeShops.forEach(cakeShop -> this.cakeShops.add(
+			CakeShopParam.builder()
 				.cakeShopId(cakeShop.getId())
 				.cakeShopName(cakeShop.getShopName())
 				.cakeShopBio(cakeShop.getShopBio())
 				.thumbnailUrl(cakeShop.getThumbnailUrl())
 				.cakeImageUrls(new HashSet<>())
+				.operationDays(null)
 				.build()
 		));
 	}
 
 	private void matchRepresentCakeImagesByMaxFour(List<CakeImageResponseParam> cakes) {
-		Map<Long, CakeShopMapParam> map = new HashMap<>();
+		Map<Long, CakeShopParam> map = new HashMap<>();
 
 		for (CakeImageResponseParam cake : cakes) {
-			CakeShopMapParam param;
+			CakeShopParam param;
 
 			if (map.containsKey(cake.cakeShopId())) {
 				param = map.get(cake.cakeShopId());
@@ -58,13 +59,13 @@ public class CakeShopByMaps {
 		}
 	}
 
-	private boolean isCakeImageUrlsCountLessThanFour(CakeShopMapParam param) {
+	private boolean isCakeImageUrlsCountLessThanFour(CakeShopParam param) {
 		return param.getCakeImageUrls().size() < 4;
 	}
 
-	private CakeShopMapParam findCakeShop(Long cakeShopId) {
-		return cakeShopByMaps.stream()
-			.filter(cakeShopMapParam -> Objects.equals(cakeShopMapParam.getCakeShopId(), cakeShopId))
+	private CakeShopParam findCakeShop(Long cakeShopId) {
+		return cakeShops.stream()
+			.filter(cakeShopParam -> Objects.equals(cakeShopParam.getCakeShopId(), cakeShopId))
 			.findFirst()
 			.orElseThrow(() -> new CakkException(ReturnCode.NOT_EXIST_CAKE_SHOP));
 	}

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/bo/CakeShops.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/bo/CakeShops.java
@@ -29,8 +29,7 @@ public class CakeShops {
 	public CakeShops(
 		List<CakeShopByKeywordParam> cakeShops,
 		List<ShopOperationParam> cakeShopOperations,
-		List<CakeImageResponseParam> cakeImages
-		) {
+		List<CakeImageResponseParam> cakeImages) {
 		Map<Long, CakeShopParam> map = new HashMap<>();
 		this.cakeShops = new ArrayList<>();
 		initCakeShopBySearchKeyword(cakeShops);

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/bo/CakeShops.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/bo/CakeShops.java
@@ -10,7 +10,9 @@ import java.util.Objects;
 import com.cakk.common.enums.ReturnCode;
 import com.cakk.common.exception.CakkException;
 import com.cakk.domain.mysql.dto.param.cake.CakeImageResponseParam;
+import com.cakk.domain.mysql.dto.param.shop.CakeShopByKeywordParam;
 import com.cakk.domain.mysql.dto.param.shop.CakeShopParam;
+import com.cakk.domain.mysql.dto.param.shop.ShopOperationParam;
 import com.cakk.domain.mysql.entity.shop.CakeShop;
 
 public class CakeShops {
@@ -18,13 +20,39 @@ public class CakeShops {
 	private List<CakeShopParam> cakeShops;
 
 	public CakeShops(List<CakeShop> cakeShops, List<CakeImageResponseParam> cakes) {
+		Map<Long, CakeShopParam> map = new HashMap<>();
 		this.cakeShops = new ArrayList<>();
 		initCakeShopByLocationBased(cakeShops);
-		matchRepresentCakeImagesByMaxFour(cakes);
+		matchRepresentCakeImagesByMaxFour(map, cakes);
+	}
+
+	public CakeShops(
+		List<CakeShopByKeywordParam> cakeShops,
+		List<ShopOperationParam> cakeShopOperations,
+		List<CakeImageResponseParam> cakeImages
+		) {
+		Map<Long, CakeShopParam> map = new HashMap<>();
+		this.cakeShops = new ArrayList<>();
+		initCakeShopBySearchKeyword(cakeShops);
+		matchRepresentCakeImagesByMaxFour(map, cakeImages);
+		matchCakeShopOperations(map, cakeShopOperations);
 	}
 
 	public List<CakeShopParam> getCakeShops() {
 		return cakeShops;
+	}
+
+	private void initCakeShopBySearchKeyword(List<CakeShopByKeywordParam> cakeShops) {
+		cakeShops.forEach(cakeShop -> this.cakeShops.add(
+			CakeShopParam.builder()
+				.cakeShopId(cakeShop.cakeShopId())
+				.cakeShopBio(cakeShop.cakeShopBio())
+				.cakeShopName(cakeShop.cakeShopName())
+				.thumbnailUrl(cakeShop.thumbnailUrl())
+				.cakeImageUrls(new HashSet<>())
+				.operationDays(new ArrayList<>())
+				.build()
+		));
 	}
 
 	private void initCakeShopByLocationBased(List<CakeShop> cakeShops) {
@@ -40,9 +68,7 @@ public class CakeShops {
 		));
 	}
 
-	private void matchRepresentCakeImagesByMaxFour(List<CakeImageResponseParam> cakes) {
-		Map<Long, CakeShopParam> map = new HashMap<>();
-
+	private void matchRepresentCakeImagesByMaxFour(Map<Long, CakeShopParam> map, List<CakeImageResponseParam> cakes) {
 		for (CakeImageResponseParam cake : cakes) {
 			CakeShopParam param;
 
@@ -56,6 +82,21 @@ public class CakeShops {
 			if (isCakeImageUrlsCountLessThanFour(param)) {
 				param.addCakeImageUrl(cake.cakeImageUrl());
 			}
+		}
+	}
+
+	private void matchCakeShopOperations(Map<Long, CakeShopParam> map, List<ShopOperationParam> cakeOperations) {
+		for (ShopOperationParam cakeOperation : cakeOperations) {
+			CakeShopParam param;
+
+			if (map.containsKey(cakeOperation.cakeShopId())) {
+				param = map.get(cakeOperation.cakeShopId());
+			} else {
+				param = findCakeShop(cakeOperation.cakeShopId());
+				map.put(cakeOperation.cakeShopId(), param);
+			}
+
+			param.setOperationDay(cakeOperation);
 		}
 	}
 

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/dto/param/cake/CakeSearchParam.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/dto/param/cake/CakeSearchParam.java
@@ -4,7 +4,7 @@ import org.locationtech.jts.geom.Point;
 
 public record CakeSearchParam(
 
-	Long cursorId,
+	Long cakeId,
 	String keyword,
 	Point location,
 	Integer pageSize

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/dto/param/shop/CakeShopByKeywordParam.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/dto/param/shop/CakeShopByKeywordParam.java
@@ -1,0 +1,9 @@
+package com.cakk.domain.mysql.dto.param.shop;
+
+public record CakeShopByKeywordParam(
+	Long cakeShopId,
+	String thumbnailUrl,
+	String cakeShopName,
+	String cakeShopBio
+) {
+}

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/dto/param/shop/CakeShopParam.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/dto/param/shop/CakeShopParam.java
@@ -1,5 +1,6 @@
 package com.cakk.domain.mysql.dto.param.shop;
 
+import java.util.List;
 import java.util.Set;
 
 import lombok.AccessLevel;
@@ -12,13 +13,14 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
-public class CakeShopMapParam {
+public class CakeShopParam {
 
 	private Long cakeShopId;
 	private String thumbnailUrl;
 	private String cakeShopName;
 	private String cakeShopBio;
 	private Set<String> cakeImageUrls;
+	private List<CakeShopOperationParam> operationDays;
 
 	public void addCakeImageUrl(String cakeImageUrl) {
 		cakeImageUrls.add(cakeImageUrl);

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/dto/param/shop/CakeShopParam.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/dto/param/shop/CakeShopParam.java
@@ -25,5 +25,15 @@ public class CakeShopParam {
 	public void addCakeImageUrl(String cakeImageUrl) {
 		cakeImageUrls.add(cakeImageUrl);
 	}
+
+	public void setOperationDay(ShopOperationParam operationDay) {
+		operationDays.add(
+			new CakeShopOperationParam(
+				operationDay.operationDay(),
+				operationDay.operationStartTime(),
+				operationDay.operationEndTime()
+			)
+		);
+	}
 }
 

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/dto/param/shop/CakeShopSearchParam.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/dto/param/shop/CakeShopSearchParam.java
@@ -1,0 +1,11 @@
+package com.cakk.domain.mysql.dto.param.shop;
+
+import org.locationtech.jts.geom.Point;
+
+public record CakeShopSearchParam(
+	Long cakeShopId,
+	String keyword,
+	Point location,
+	Integer pageSize
+) {
+}

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/dto/param/shop/CakeShopSearchResponseParam.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/dto/param/shop/CakeShopSearchResponseParam.java
@@ -1,0 +1,14 @@
+package com.cakk.domain.mysql.dto.param.shop;
+
+import java.util.List;
+import java.util.Set;
+
+public class CakeShopSearchResponseParam {
+
+	private Long cakeShopId;
+	private String thumbnailUrl;
+	private String cakeShopName;
+	private String cakeShopBio;
+	private List<CakeShopOperationParam> operationDays;
+	private Set<String> cakeImageUrls;
+}

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/dto/param/shop/ShopOperationParam.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/dto/param/shop/ShopOperationParam.java
@@ -1,0 +1,13 @@
+package com.cakk.domain.mysql.dto.param.shop;
+
+import java.time.LocalTime;
+
+import com.cakk.common.enums.Days;
+
+public record ShopOperationParam(
+	Long cakeShopId,
+	Days operationDay,
+	LocalTime operationStartTime,
+	LocalTime operationEndTime
+) {
+}

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/query/CakeLikeQueryRepository.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/query/CakeLikeQueryRepository.java
@@ -16,7 +16,6 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
 
-import com.cakk.domain.mysql.dto.param.cake.CakeImageResponseParam;
 import com.cakk.domain.mysql.dto.param.like.LikeCakeImageResponseParam;
 
 @RequiredArgsConstructor

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/query/CakeQueryRepository.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/query/CakeQueryRepository.java
@@ -11,6 +11,7 @@ import java.util.List;
 import org.locationtech.jts.geom.Point;
 import org.springframework.stereotype.Repository;
 
+import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -100,12 +101,7 @@ public class CakeQueryRepository {
 			.leftJoin(cakeCategory)
 			.on(cakeCategory.cake.eq(cake))
 			.where(
-				includeDistance(location)
-					.or(containsKeywordInShopBio(keyword))
-					.or(containsKeywordInShopDesc(keyword))
-					.or(containsKeywordInTagName(keyword))
-					.or(includeDistance(location))
-				,ltCakeId(cakeId)
+				includeDistance(location).and(containKeyword(keyword)), ltCakeId(cakeId)
 			)
 			.orderBy(cakeIdDesc())
 			.limit(pageSize)
@@ -130,6 +126,18 @@ public class CakeQueryRepository {
 
 	private BooleanExpression includeCakeShopIds(List<Long> cakeShopIds) {
 		return cake.cakeShop.id.in(cakeShopIds);
+	}
+
+	private BooleanBuilder containKeyword(String keyword) {
+		BooleanBuilder builder = new BooleanBuilder();
+
+		if (nonNull(keyword)) {
+			builder.or(containsKeywordInShopBio(keyword));
+			builder.or(containsKeywordInShopDesc(keyword));
+			builder.or(containsKeywordInTagName(keyword));
+		}
+
+		return builder;
 	}
 
 	private BooleanExpression containsKeywordInShopBio(String keyword) {

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/query/CakeQueryRepository.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/query/CakeQueryRepository.java
@@ -100,14 +100,15 @@ public class CakeQueryRepository {
 			.leftJoin(cakeCategory)
 			.on(cakeCategory.cake.eq(cake))
 			.where(
-				ltCakeId(cakeId)
+				includeDistance(location)
 					.or(containsKeywordInShopBio(keyword))
 					.or(containsKeywordInShopDesc(keyword))
 					.or(containsKeywordInTagName(keyword))
 					.or(includeDistance(location))
+				,ltCakeId(cakeId)
 			)
-			.limit(pageSize)
 			.orderBy(cakeIdDesc())
+			.limit(pageSize)
 			.fetch();
 	}
 

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/query/CakeShopOperationQueryRepository.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/query/CakeShopOperationQueryRepository.java
@@ -7,13 +7,14 @@ import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
-import com.cakk.domain.mysql.dto.param.shop.ShopOperationParam;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
+
+import com.cakk.domain.mysql.dto.param.shop.ShopOperationParam;
 
 @Repository
 @RequiredArgsConstructor

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/query/CakeShopOperationQueryRepository.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/query/CakeShopOperationQueryRepository.java
@@ -1,0 +1,48 @@
+package com.cakk.domain.mysql.repository.query;
+
+import static com.cakk.domain.mysql.entity.shop.QCakeShop.*;
+import static com.cakk.domain.mysql.entity.shop.QCakeShopOperation.*;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.cakk.domain.mysql.dto.param.shop.ShopOperationParam;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class CakeShopOperationQueryRepository {
+
+	private final JPAQueryFactory queryFactory;
+
+	public List<ShopOperationParam> findByCakeShopIds(List<Long> cakeShopIds) {
+		return queryFactory
+			.select(Projections.constructor(ShopOperationParam.class,
+				cakeShop.id,
+				cakeShopOperation.operationDay,
+				cakeShopOperation.operationStartTime,
+				cakeShopOperation.operationEndTime))
+			.from(cakeShopOperation)
+			.innerJoin(cakeShop)
+			.on(cakeShopOperation.cakeShop.eq(cakeShop))
+			.where(
+				includeCakeShopIds(cakeShopIds)
+			)
+			.orderBy(cakeShopIdsAsc())
+			.fetch();
+	}
+
+	private BooleanExpression includeCakeShopIds(List<Long> cakeShopIds) {
+		return cakeShopOperation.cakeShop.id.in(cakeShopIds);
+	}
+
+	private OrderSpecifier<Long> cakeShopIdsAsc() {
+		return cakeShopOperation.id.asc();
+	}
+}

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/query/CakeShopQueryRepository.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/query/CakeShopQueryRepository.java
@@ -11,6 +11,7 @@ import java.util.List;
 import org.locationtech.jts.geom.Point;
 import org.springframework.stereotype.Repository;
 
+import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -104,13 +105,12 @@ public class CakeShopQueryRepository {
 			))
 			.from(cakeShop)
 			.where(
-				ltCakeShopId(cakeShopId)
-					.or(containsKeywordInShopDesc(keyword))
-					.or(containsKeywordInShopBio(keyword))
-					.or(includeDistance(location))
+				includeDistance(location)
+					.and(containKeyword(keyword))
+				, ltCakeShopId(cakeShopId)
 			)
-			.limit(pageSize)
 			.orderBy(cakeShopIdDesc())
+			.limit(pageSize)
 			.fetch();
 	}
 
@@ -124,6 +124,17 @@ public class CakeShopQueryRepository {
 		}
 
 		return cakeShop.id.lt(cakeShopId);
+	}
+
+	private BooleanBuilder containKeyword(String keyword) {
+		BooleanBuilder builder = new BooleanBuilder();
+
+		if (nonNull(keyword)) {
+			builder.or(containsKeywordInShopBio(keyword));
+			builder.or(containsKeywordInShopDesc(keyword));
+		}
+
+		return builder;
 	}
 
 	private BooleanExpression containsKeywordInShopBio(String keyword) {

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/query/CakeShopQueryRepository.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/query/CakeShopQueryRepository.java
@@ -105,9 +105,7 @@ public class CakeShopQueryRepository {
 			))
 			.from(cakeShop)
 			.where(
-				includeDistance(location)
-					.and(containKeyword(keyword))
-				, ltCakeShopId(cakeShopId)
+				includeDistance(location).and(containKeyword(keyword)), ltCakeShopId(cakeShopId)
 			)
 			.orderBy(cakeShopIdDesc())
 			.limit(pageSize)

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/query/CakeShopQueryRepository.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/query/CakeShopQueryRepository.java
@@ -102,6 +102,7 @@ public class CakeShopQueryRepository {
 				cakeShop.shopName,
 				cakeShop.shopBio
 			))
+			.from(cakeShop)
 			.where(
 				ltCakeShopId(cakeShopId)
 					.or(containsKeywordInShopDesc(keyword))

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/query/CakeShopQueryRepository.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/query/CakeShopQueryRepository.java
@@ -11,7 +11,6 @@ import java.util.List;
 import org.locationtech.jts.geom.Point;
 import org.springframework.stereotype.Repository;
 
-import com.cakk.domain.mysql.dto.param.shop.CakeShopByKeywordParam;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -20,6 +19,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
 
+import com.cakk.domain.mysql.dto.param.shop.CakeShopByKeywordParam;
 import com.cakk.domain.mysql.dto.param.shop.CakeShopDetailParam;
 import com.cakk.domain.mysql.dto.param.shop.CakeShopInfoParam;
 import com.cakk.domain.mysql.dto.param.shop.CakeShopLinkParam;

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/reader/CakeReader.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/reader/CakeReader.java
@@ -11,7 +11,6 @@ import com.cakk.domain.mysql.annotation.Reader;
 import com.cakk.domain.mysql.dto.param.cake.CakeImageResponseParam;
 import com.cakk.domain.mysql.dto.param.cake.CakeSearchParam;
 import com.cakk.domain.mysql.entity.cake.Cake;
-import com.cakk.domain.mysql.entity.shop.CakeShop;
 import com.cakk.domain.mysql.repository.jpa.CakeJpaRepository;
 import com.cakk.domain.mysql.repository.query.CakeQueryRepository;
 
@@ -40,7 +39,7 @@ public class CakeReader {
 
 	public List<CakeImageResponseParam> searchCakeImagesByCursorAndSearchKeyword(CakeSearchParam param) {
 		return cakeQueryRepository.searchCakeImagesByCursorAndSearchKeyword(
-			param.cursorId(),
+			param.cakeId(),
 			param.keyword(),
 			param.location(),
 			param.pageSize()

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/reader/CakeShopOperationReader.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/reader/CakeShopOperationReader.java
@@ -5,16 +5,23 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 
 import com.cakk.domain.mysql.annotation.Reader;
+import com.cakk.domain.mysql.dto.param.shop.ShopOperationParam;
 import com.cakk.domain.mysql.entity.shop.CakeShopOperation;
 import com.cakk.domain.mysql.repository.jpa.CakeShopOperationJpaRepository;
+import com.cakk.domain.mysql.repository.query.CakeShopOperationQueryRepository;
 
 @Reader
 @RequiredArgsConstructor
 public class CakeShopOperationReader {
 
 	private final CakeShopOperationJpaRepository cakeShopOperationJpaRepository;
+	private final CakeShopOperationQueryRepository cakeShopOperationQueryRepository;
 
 	public List<CakeShopOperation> findAllByCakeShopId(Long cakeShopId) {
 		return cakeShopOperationJpaRepository.findAllByCakeShopId(cakeShopId);
+	}
+
+	public List<ShopOperationParam> searchShopOperationsByCakeShops(List<Long> cakeShopIds) {
+		return cakeShopOperationQueryRepository.findByCakeShopIds(cakeShopIds);
 	}
 }

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/reader/CakeShopReader.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/reader/CakeShopReader.java
@@ -11,8 +11,11 @@ import lombok.RequiredArgsConstructor;
 import com.cakk.common.enums.ReturnCode;
 import com.cakk.common.exception.CakkException;
 import com.cakk.domain.mysql.annotation.Reader;
+import com.cakk.domain.mysql.dto.param.shop.CakeShopByKeywordParam;
 import com.cakk.domain.mysql.dto.param.shop.CakeShopDetailParam;
 import com.cakk.domain.mysql.dto.param.shop.CakeShopInfoParam;
+import com.cakk.domain.mysql.dto.param.shop.CakeShopOperationParam;
+import com.cakk.domain.mysql.dto.param.shop.CakeShopSearchParam;
 import com.cakk.domain.mysql.dto.param.shop.CakeShopSimpleParam;
 import com.cakk.domain.mysql.entity.shop.CakeShop;
 import com.cakk.domain.mysql.entity.user.BusinessInformation;
@@ -75,5 +78,14 @@ public class CakeShopReader {
 
 	public List<CakeShop> searchShopByLocationBased(Point point) {
 		return cakeShopJpaRepository.findByLocationBased(point);
+	}
+
+	public List<CakeShopByKeywordParam> searchShopByKeyword(CakeShopSearchParam param) {
+		return cakeShopQueryRepository.findByKeywordWithLocation(
+			param.cakeShopId(),
+			param.keyword(),
+			param.location(),
+			param.pageSize()
+		);
 	}
 }

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/reader/CakeShopReader.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/reader/CakeShopReader.java
@@ -14,7 +14,6 @@ import com.cakk.domain.mysql.annotation.Reader;
 import com.cakk.domain.mysql.dto.param.shop.CakeShopByKeywordParam;
 import com.cakk.domain.mysql.dto.param.shop.CakeShopDetailParam;
 import com.cakk.domain.mysql.dto.param.shop.CakeShopInfoParam;
-import com.cakk.domain.mysql.dto.param.shop.CakeShopOperationParam;
 import com.cakk.domain.mysql.dto.param.shop.CakeShopSearchParam;
 import com.cakk.domain.mysql.dto.param.shop.CakeShopSimpleParam;
 import com.cakk.domain.mysql.entity.shop.CakeShop;


### PR DESCRIPTION
> ### Issue Number

#72 

> ### Description

- OperationDays에 대해 공통 dto로 추출했습니다
- CakeShops에 대한 일급 컬렉션에서 컬렉션 기능을 추가했습니다: 영업 운영일을 매칭해주기 위한 기능
- PointMapper에 대한 책임 중, null 예외 처리를 추가했습니다
- 위치 기반의 케이크샵 조회 및 검색 조회를 위한 테스트를 추가했습니다

서울에서 사용자의 위치가 다음 사진과 같을 때, 조회되는 데이터 7개
동탄 케이크샵을 기준으로 3개 로 분류했습니다

<img width="1221" alt="스크린샷 2024-06-12 오후 10 52 50" src="https://github.com/CAKK-DEV/cakk-server/assets/86272688/7a85f334-9527-40e7-9621-3e267cf69bb9">


케이크 샵 조회 시, 쿼리를 3개로 분류했습니다
최대 10개의 커서 기반 페이지네이션을 제공하는데, 한방 쿼리로 구현하여 limit = 10개의 페이지네이션을 구현한다면 최대 10개의 케이크샵의 조회되지 않습니다. 이를 위해서는 서브 쿼리를 활용해야 합니다.
그 이유는 케이크 이미지 그리고 케이크 샵 운영일 Join으로 인해 중복되는 데이터가 Join되기 때문입니다.

해결 방안 1. 케이크 영업일 역정규화 -> Join을 줄여줘서 쿼리 개수를 줄일 수 있습니다
해결 방안 2. 케이크 이미지 Json Array로 Database에 저장하기 -> 문자열로 길게 저장하는게 성능 저하를 유발할 수 있지만 쿼리 개수를 줄일 수는 있다고 판단했습니다

더 좋은 방법도 있을 것 같은데  일단 구현에 집중했습니다

따라서, 기능 구현 조건에 존재하는 케이크 샵의 영업일 정보와 케이크 샵의 대표 이미지 4개를 매칭해주는 Responsibility를 일급 컬렉션 CakeShops로 네이밍 리팩토링하여 책임을 부여했습니다
> ### Core Code

```java
	public CakeShops(
		List<CakeShopByKeywordParam> cakeShops,
		List<ShopOperationParam> cakeShopOperations,
		List<CakeImageResponseParam> cakeImages
		) {
		Map<Long, CakeShopParam> map = new HashMap<>();
		this.cakeShops = new ArrayList<>();
		initCakeShopBySearchKeyword(cakeShops); // 검색어로 필터링된 케이크 샵
		matchRepresentCakeImagesByMaxFour(map, cakeImages); // 케이크샵 마다 최대 대표 이미지 4개 매칭
		matchCakeShopOperations(map, cakeShopOperations); // 케이크 샵의 케이크샵 영업일 매칭
	}
```

> ### etc
