### PR TITLE
Feature: 케이크 샵 외부 링크 수정 기능 추가

### DIFF
--- a/cakk-api/src/main/java/com/cakk/api/controller/shop/ShopController.java
+++ b/cakk-api/src/main/java/com/cakk/api/controller/shop/ShopController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 import lombok.RequiredArgsConstructor;
 
 import com.cakk.api.annotation.SignInUser;
+import com.cakk.api.dto.request.link.UpdateLinkRequest;
 import com.cakk.api.dto.request.shop.CakeShopSearchRequest;
 import com.cakk.api.dto.request.shop.CreateShopRequest;
 import com.cakk.api.dto.request.shop.PromotionRequest;
@@ -120,6 +121,17 @@ public class ShopController {
 		@Valid @RequestBody UpdateShopRequest request
 	) {
 		shopService.updateDefaultInformation(request.toParam(user, cakeShopId));
+
+		return ApiResponse.success();
+	}
+
+	@PutMapping("/{cakeShopId}/links")
+	public ApiResponse<Void> updateShopLinks(
+		@SignInUser User user,
+		@PathVariable Long cakeShopId,
+		@Valid @RequestBody UpdateLinkRequest request
+	) {
+		shopService.updateShopLinks(request.toParam(user, cakeShopId));
 
 		return ApiResponse.success();
 	}

--- a/cakk-api/src/main/java/com/cakk/api/dto/request/link/UpdateLinkRequest.java
+++ b/cakk-api/src/main/java/com/cakk/api/dto/request/link/UpdateLinkRequest.java
@@ -1,0 +1,47 @@
+package com.cakk.api.dto.request.link;
+
+import static java.util.Objects.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.cakk.api.mapper.LinkMapper;
+import com.cakk.domain.mysql.dto.param.link.UpdateLinkParam;
+import com.cakk.domain.mysql.entity.shop.CakeShopLink;
+import com.cakk.domain.mysql.entity.user.User;
+
+
+import jakarta.validation.constraints.Size;
+
+public record UpdateLinkRequest(
+	@Size(min = 1, max = 200)
+	String instagram,
+	@Size(min = 1, max = 200)
+	String kakao,
+	@Size(min = 1, max = 200)
+	String web
+) {
+
+	public UpdateLinkParam toParam(User user, Long cakeShopId) {
+		List<CakeShopLink> cakeShopLinks = new ArrayList<>();
+		CakeShopLink instagramLink = LinkMapper.supplyCakeShopLinkByInstagram(instagram);
+		CakeShopLink kakaoLink = LinkMapper.supplyCakeShopLinkByKakao(kakao);
+		CakeShopLink webLink = LinkMapper.supplyCakeShopLinkByWeb(web);
+
+		addLink(cakeShopLinks, instagramLink);
+		addLink(cakeShopLinks, kakaoLink);
+		addLink(cakeShopLinks, webLink);
+
+		return new UpdateLinkParam(
+			user,
+			cakeShopId,
+			cakeShopLinks
+		);
+	}
+
+	private void addLink(List<CakeShopLink> cakeShopLinks, CakeShopLink cakeShopLink) {
+		if (nonNull(cakeShopLink)) {
+			cakeShopLinks.add(cakeShopLink);
+		}
+	}
+}

--- a/cakk-api/src/main/java/com/cakk/api/dto/request/link/UpdateLinkRequest.java
+++ b/cakk-api/src/main/java/com/cakk/api/dto/request/link/UpdateLinkRequest.java
@@ -5,13 +5,12 @@ import static java.util.Objects.*;
 import java.util.ArrayList;
 import java.util.List;
 
+import jakarta.validation.constraints.Size;
+
 import com.cakk.api.mapper.LinkMapper;
 import com.cakk.domain.mysql.dto.param.link.UpdateLinkParam;
 import com.cakk.domain.mysql.entity.shop.CakeShopLink;
 import com.cakk.domain.mysql.entity.user.User;
-
-
-import jakarta.validation.constraints.Size;
 
 public record UpdateLinkRequest(
 	@Size(min = 1, max = 200)

--- a/cakk-api/src/main/java/com/cakk/api/mapper/LinkMapper.java
+++ b/cakk-api/src/main/java/com/cakk/api/mapper/LinkMapper.java
@@ -1,10 +1,11 @@
 package com.cakk.api.mapper;
 
-import com.cakk.common.enums.LinkKind;
-import com.cakk.domain.mysql.entity.shop.CakeShopLink;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+
+import com.cakk.common.enums.LinkKind;
+import com.cakk.domain.mysql.entity.shop.CakeShopLink;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class LinkMapper {

--- a/cakk-api/src/main/java/com/cakk/api/mapper/LinkMapper.java
+++ b/cakk-api/src/main/java/com/cakk/api/mapper/LinkMapper.java
@@ -1,0 +1,41 @@
+package com.cakk.api.mapper;
+
+import com.cakk.common.enums.LinkKind;
+import com.cakk.domain.mysql.entity.shop.CakeShopLink;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class LinkMapper {
+
+	public static CakeShopLink supplyCakeShopLinkByInstagram(String instagram) {
+		if (instagram == null) {
+			return null;
+		}
+		return CakeShopLink.builder()
+			.linkKind(LinkKind.INSTAGRAM)
+			.linkPath(instagram)
+			.build();
+	}
+
+	public static CakeShopLink supplyCakeShopLinkByKakao(String kakao) {
+		if (kakao == null) {
+			return null;
+		}
+		return CakeShopLink.builder()
+			.linkKind(LinkKind.KAKAOTALK)
+			.linkPath(kakao)
+			.build();
+	}
+
+	public static CakeShopLink supplyCakeShopLinkByWeb(String web) {
+		if (web == null) {
+			return null;
+		}
+		return CakeShopLink.builder()
+			.linkKind(LinkKind.WEB)
+			.linkPath(web)
+			.build();
+	}
+}

--- a/cakk-api/src/main/java/com/cakk/api/service/shop/ShopService.java
+++ b/cakk-api/src/main/java/com/cakk/api/service/shop/ShopService.java
@@ -84,6 +84,12 @@ public class ShopService {
 		cakeShop.updateDefaultInformation(param);
 	}
 
+	@Transactional
+	public void updateShopLinks(UpdateLinkParam param) {
+		final CakeShop cakeShop = cakeShopReader.findWithShopLinks(param.user(), param.cakeShopId());
+		cakeShop.updateShopLinks(param.cakeShopLinks());
+	}
+
 	@Transactional(readOnly = true)
 	public void requestCertificationBusinessOwner(CertificationParam param) {
 		BusinessInformation businessInformation;

--- a/cakk-api/src/main/java/com/cakk/api/service/shop/ShopService.java
+++ b/cakk-api/src/main/java/com/cakk/api/service/shop/ShopService.java
@@ -22,6 +22,7 @@ import com.cakk.api.mapper.PointMapper;
 import com.cakk.api.mapper.ShopMapper;
 import com.cakk.domain.mysql.bo.CakeShops;
 import com.cakk.domain.mysql.dto.param.cake.CakeImageResponseParam;
+import com.cakk.domain.mysql.dto.param.link.UpdateLinkParam;
 import com.cakk.domain.mysql.dto.param.shop.CakeShopByKeywordParam;
 import com.cakk.domain.mysql.dto.param.shop.CakeShopDetailParam;
 import com.cakk.domain.mysql.dto.param.shop.CakeShopInfoParam;
@@ -78,7 +79,7 @@ public class ShopService {
 
 	@Transactional
 	public void updateDefaultInformation(CakeShopUpdateParam param) {
-		final CakeShop cakeShop = cakeShopReader.findWithBusinessInformationAndOwnerById(param.cakeShopId());
+		final CakeShop cakeShop = cakeShopReader.findWithBusinessInformationAndOwnerById(param.user(), param.cakeShopId());
 
 		cakeShop.updateDefaultInformation(param);
 	}

--- a/cakk-api/src/test/java/com/cakk/api/integration/shop/ShopIntegrationTest.java
+++ b/cakk-api/src/test/java/com/cakk/api/integration/shop/ShopIntegrationTest.java
@@ -22,6 +22,7 @@ import net.jqwik.api.Arbitraries;
 
 import com.cakk.api.common.annotation.TestWithDisplayName;
 import com.cakk.api.common.base.IntegrationTest;
+import com.cakk.api.dto.request.link.UpdateLinkRequest;
 import com.cakk.api.dto.request.shop.UpdateShopRequest;
 import com.cakk.api.dto.request.user.CertificationRequest;
 import com.cakk.api.dto.response.shop.CakeShopByMapResponse;
@@ -447,6 +448,31 @@ class ShopIntegrationTest extends IntegrationTest {
 			.fromUriString(url)
 			.buildAndExpand(cakeShopId);
 		final UpdateShopRequest request = getConstructorMonkey().giveMeBuilder(UpdateShopRequest.class).sample();
+
+		// when
+		final ResponseEntity<ApiResponse> responseEntity = restTemplate.exchange(
+			uriComponents.toUriString(),
+			HttpMethod.PUT,
+			new HttpEntity<>(request, getAuthHeader()),
+			ApiResponse.class);
+
+		// then
+		final ApiResponse response = objectMapper.convertValue(responseEntity.getBody(), ApiResponse.class);
+
+		assertEquals(HttpStatusCode.valueOf(200), responseEntity.getStatusCode());
+		assertEquals(ReturnCode.SUCCESS.getCode(), response.getReturnCode());
+		assertEquals(ReturnCode.SUCCESS.getMessage(), response.getReturnMessage());
+	}
+
+	@TestWithDisplayName("케이크샵 외부 링크 업데이트에 성공한다")
+	void updateShopLinks() {
+		// given
+		final Long cakeShopId = 1L;
+		final String url = "%s%d%s/{cakeShopId}/links".formatted(BASE_URL, port, API_URL);
+		final UriComponents uriComponents = UriComponentsBuilder
+			.fromUriString(url)
+			.buildAndExpand(cakeShopId);
+		final UpdateLinkRequest request = getConstructorMonkey().giveMeBuilder(UpdateLinkRequest.class).sample();
 
 		// when
 		final ResponseEntity<ApiResponse> responseEntity = restTemplate.exchange(

--- a/cakk-domain/mysql/build.gradle
+++ b/cakk-domain/mysql/build.gradle
@@ -44,3 +44,13 @@ bootJar {
 jar {
     enabled = true
 }
+
+test {
+	testLogging {
+		showStandardStreams = true
+		showCauses = true
+		showExceptions = true
+		showStackTraces = true
+		exceptionFormat = 'full'
+	}
+}

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/dto/param/link/UpdateLinkParam.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/dto/param/link/UpdateLinkParam.java
@@ -1,0 +1,13 @@
+package com.cakk.domain.mysql.dto.param.link;
+
+import java.util.List;
+
+import com.cakk.domain.mysql.entity.shop.CakeShopLink;
+import com.cakk.domain.mysql.entity.user.User;
+
+public record UpdateLinkParam(
+	User user,
+	Long cakeShopId,
+	List<CakeShopLink> cakeShopLinks
+) {
+}

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/entity/shop/CakeShop.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/entity/shop/CakeShop.java
@@ -1,12 +1,15 @@
 package com.cakk.domain.mysql.entity.shop;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 
@@ -19,12 +22,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import com.cakk.common.enums.ReturnCode;
-import com.cakk.common.exception.CakkException;
 import com.cakk.domain.mysql.dto.param.shop.CakeShopUpdateParam;
 import com.cakk.domain.mysql.entity.audit.AuditEntity;
 import com.cakk.domain.mysql.entity.user.BusinessInformation;
-import com.cakk.domain.mysql.entity.user.User;
 
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -75,6 +75,9 @@ public class CakeShop extends AuditEntity {
 	@OneToOne(mappedBy = "cakeShop")
 	private BusinessInformation businessInformation;
 
+	@OneToMany(mappedBy = "cakeShop")
+	private List<CakeShopLink> cakeShopLinks = new ArrayList<>();
+
 	@Builder
 	public CakeShop(
 		String shopName,
@@ -108,18 +111,8 @@ public class CakeShop extends AuditEntity {
 	}
 
 	public void updateDefaultInformation(CakeShopUpdateParam param) {
-		User owner = param.user();
-
-		if (isNotOwner(owner)) {
-			throw new CakkException(ReturnCode.NOT_CAKE_SHOP_OWNER);
-		}
-
 		shopName = param.shopName();
 		shopBio = param.shopBio();
 		shopDescription = param.shopDescription();
-	}
-
-	private boolean isNotOwner(User owner) {
-		return businessInformation.getUser().getId() != owner.getId();
 	}
 }

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/entity/shop/CakeShop.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/entity/shop/CakeShop.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -75,7 +76,7 @@ public class CakeShop extends AuditEntity {
 	@OneToOne(mappedBy = "cakeShop")
 	private BusinessInformation businessInformation;
 
-	@OneToMany(mappedBy = "cakeShop")
+	@OneToMany(mappedBy = "cakeShop", cascade = CascadeType.PERSIST, orphanRemoval = true)
 	private List<CakeShopLink> cakeShopLinks = new ArrayList<>();
 
 	@Builder
@@ -114,5 +115,14 @@ public class CakeShop extends AuditEntity {
 		shopName = param.shopName();
 		shopBio = param.shopBio();
 		shopDescription = param.shopDescription();
+	}
+
+	public void updateShopLinks(List<CakeShopLink> cakeShopLinks) {
+		this.cakeShopLinks.clear();
+
+		cakeShopLinks.forEach(cakeShopLink -> {
+			cakeShopLink.updateCakeShop(this);
+			this.cakeShopLinks.add(cakeShopLink);
+		});
 	}
 }

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/entity/shop/CakeShopLink.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/entity/shop/CakeShopLink.java
@@ -48,4 +48,8 @@ public class CakeShopLink extends AuditEntity {
 		this.linkPath = linkPath;
 		this.cakeShop = cakeShop;
 	}
+
+	public void updateCakeShop(CakeShop cakeShop) {
+		this.cakeShop = cakeShop;
+	}
 }

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/query/CakeShopQueryRepository.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/query/CakeShopQueryRepository.java
@@ -14,7 +14,6 @@ import java.util.Optional;
 import org.locationtech.jts.geom.Point;
 import org.springframework.stereotype.Repository;
 
-import com.cakk.domain.mysql.entity.user.User;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
@@ -31,6 +30,7 @@ import com.cakk.domain.mysql.dto.param.shop.CakeShopLinkParam;
 import com.cakk.domain.mysql.dto.param.shop.CakeShopOperationParam;
 import com.cakk.domain.mysql.dto.param.shop.CakeShopSimpleParam;
 import com.cakk.domain.mysql.entity.shop.CakeShop;
+import com.cakk.domain.mysql.entity.user.User;
 
 @Repository
 @RequiredArgsConstructor
@@ -122,6 +122,15 @@ public class CakeShopQueryRepository {
 			.selectFrom(cakeShop)
 			.join(cakeShop.businessInformation, businessInformation)
 			.join(businessInformation.user, user)
+			.where(cakeShop.id.eq(cakeShopId), businessInformation.user.eq(owner))
+			.fetchOne());
+	}
+
+	public Optional<CakeShop> findWithShopLinks(User owner, Long cakeShopId) {
+		return Optional.ofNullable(queryFactory
+			.selectFrom(cakeShop)
+			.join(cakeShop.cakeShopLinks, cakeShopLink).fetchJoin()
+			.join(cakeShop.businessInformation, businessInformation).fetchJoin()
 			.where(cakeShop.id.eq(cakeShopId), businessInformation.user.eq(owner))
 			.fetchOne());
 	}

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/query/CakeShopQueryRepository.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/query/CakeShopQueryRepository.java
@@ -9,10 +9,12 @@ import static com.querydsl.core.group.GroupBy.*;
 import static java.util.Objects.*;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.locationtech.jts.geom.Point;
 import org.springframework.stereotype.Repository;
 
+import com.cakk.domain.mysql.entity.user.User;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
@@ -115,13 +117,13 @@ public class CakeShopQueryRepository {
 			.fetch();
 	}
 
-	public CakeShop findWithBusinessInformationAndOwnerById(Long cakeShopId) {
-		return queryFactory
+	public Optional<CakeShop> findWithBusinessInformationAndOwnerById(User owner, Long cakeShopId) {
+		return Optional.ofNullable(queryFactory
 			.selectFrom(cakeShop)
-			.join(cakeShop.businessInformation, businessInformation).fetchJoin()
-			.join(businessInformation.user, user).fetchJoin()
-			.where(cakeShop.id.eq(cakeShopId))
-			.fetchOne();
+			.join(cakeShop.businessInformation, businessInformation)
+			.join(businessInformation.user, user)
+			.where(cakeShop.id.eq(cakeShopId), businessInformation.user.eq(owner))
+			.fetchOne());
 	}
 
 	private BooleanExpression eqCakeShopId(Long cakeShopId) {

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/reader/CakeShopReader.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/reader/CakeShopReader.java
@@ -93,4 +93,9 @@ public class CakeShopReader {
 		return cakeShopQueryRepository.findWithBusinessInformationAndOwnerById(owner, cakeShopId)
 			.orElseThrow(() -> new CakkException(ReturnCode.NOT_CAKE_SHOP_OWNER));
 	}
+
+	public CakeShop findWithShopLinks(User owner, Long cakeShopId) {
+		return cakeShopQueryRepository.findWithShopLinks(owner, cakeShopId)
+			.orElseThrow(() -> new CakkException(ReturnCode.NOT_CAKE_SHOP_OWNER));
+	}
 }

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/reader/CakeShopReader.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/reader/CakeShopReader.java
@@ -18,6 +18,7 @@ import com.cakk.domain.mysql.dto.param.shop.CakeShopSearchParam;
 import com.cakk.domain.mysql.dto.param.shop.CakeShopSimpleParam;
 import com.cakk.domain.mysql.entity.shop.CakeShop;
 import com.cakk.domain.mysql.entity.user.BusinessInformation;
+import com.cakk.domain.mysql.entity.user.User;
 import com.cakk.domain.mysql.repository.jpa.BusinessInformationJpaRepository;
 import com.cakk.domain.mysql.repository.jpa.CakeShopJpaRepository;
 import com.cakk.domain.mysql.repository.query.CakeShopQueryRepository;
@@ -88,7 +89,8 @@ public class CakeShopReader {
 		);
 	}
 
-	public CakeShop findWithBusinessInformationAndOwnerById(Long cakeShopId) {
-		return cakeShopQueryRepository.findWithBusinessInformationAndOwnerById(cakeShopId);
+	public CakeShop findWithBusinessInformationAndOwnerById(User owner, Long cakeShopId) {
+		return cakeShopQueryRepository.findWithBusinessInformationAndOwnerById(owner, cakeShopId)
+			.orElseThrow(() -> new CakkException(ReturnCode.NOT_CAKE_SHOP_OWNER));
 	}
 }

--- a/cakk-domain/mysql/src/test/java/com/cakk/domain/entity/user/BusinessInformationTest.java
+++ b/cakk-domain/mysql/src/test/java/com/cakk/domain/entity/user/BusinessInformationTest.java
@@ -19,6 +19,8 @@ class BusinessInformationTest extends DomainTest {
 	private CakeShop getCakeShopFixture() {
 		return getConstructorMonkey().giveMeBuilder(CakeShop.class)
 			.set("shopName", Arbitraries.strings().withCharRange('a', 'z').ofMaxLength(30))
+			.set("shopBio", Arbitraries.strings().withCharRange('a', 'z').ofMaxLength(40))
+			.set("shopDescription", Arbitraries.strings().withCharRange('a', 'z').ofMaxLength(500))
 			.set("location", supplyPointBy(Arbitraries.doubles().sample(), Arbitraries.doubles().sample()))
 			.sample();
 	}
@@ -47,8 +49,12 @@ class BusinessInformationTest extends DomainTest {
 
 	private CertificationParam getCertificationParamFixtureWithUser(User user) {
 		return getBuilderMonkey().giveMeBuilder(CertificationParam.class)
-			.set("user", user)
+			.set("businessRegistrationImageUrl", Arbitraries.strings().withCharRange('a', 'z').ofMinLength(1).ofMaxLength(20))
+			.set("idCardImageUrl", Arbitraries.strings().withCharRange('a', 'z').ofMinLength(1).ofMaxLength(20))
+			.set("cakeShopId", Arbitraries.longs().greaterOrEqual(0))
+			.set("emergencyContact", Arbitraries.strings().withCharRange('a', 'z').ofMinLength(1).ofMaxLength(20))
 			.set("message", Arbitraries.strings().withCharRange('a', 'z').ofMaxLength(20))
+			.set("user", user)
 			.sample();
 	}
 

--- a/cakk-domain/mysql/src/test/java/com/cakk/domain/entity/user/BusinessInformationTest.java
+++ b/cakk-domain/mysql/src/test/java/com/cakk/domain/entity/user/BusinessInformationTest.java
@@ -44,6 +44,7 @@ class BusinessInformationTest extends DomainTest {
 	private User getUserFixture() {
 		return getReflectionMonkey().giveMeBuilder(User.class)
 			.set("id", Arbitraries.longs().greaterOrEqual(10))
+			.set("email", Arbitraries.strings().withCharRange('a', 'z').ofMaxLength(50))
 			.sample();
 	}
 
@@ -64,12 +65,13 @@ class BusinessInformationTest extends DomainTest {
 		BusinessInformation businessInformation = getBusinessInformationFixtureWithCakeShop();
 		User user = getUserFixture();
 		CertificationParam param = getCertificationParamFixtureWithUser(user);
+		String shopName = businessInformation.getCakeShop().getShopName();
 
 		//when
 		CertificationEvent certificationEvent = businessInformation.getRequestCertificationMessage(param);
 
 		//then
-		assertThat(certificationEvent.shopName()).isNotNull();
+		assertThat(certificationEvent.shopName()).isEqualTo(shopName);
 	}
 
 	@Test


### PR DESCRIPTION
> ### Issue Number

#87

> ### Description

- JPA가 지향하는 Entity에서 도메인 로직을 담고, Cascade, Orphan Option을 활용 -> 영속성 컨텍스트를 활용하여 데이터의 정합성이 올바르게 유지될 수 있도록 코드를 작성했습니다.

> ### Core Code

```java
public void updateShopLinks(List<CakeShopLink> cakeShopLinks) {
	this.cakeShopLinks.clear(); // 영속성 컨텍스트에 올라온 기존 외부 링크 제거

	cakeShopLinks.forEach(cakeShopLink -> { // 새롭게 요청 받은 외부 링크 삽입 위한 로직
		cakeShopLink.updateCakeShop(this);
		this.cakeShopLinks.add(cakeShopLink);
	});
}
```

> ### etc
* 기존 외부 링크들이 존재하면, 해당 외부 링크가 INSTAGRAM, KAKAO, WEB인지 검사하는 로직을 통해 도메인 로직을 구상하려고 했는데 
    * 클라이언트 요청의 아무래도 PUT이다 보니 , 외부 링크에 대한 데이터 정합성을 서버에서 정확히 관리하기 위해 기존 링크 삭제 후, 새롭게 삽입하는 로직으로 작성했습니다.