### PR TITLE
Feature: 케이크 샵 좋아요 목록 조회 구현

### DIFF
--- a/cakk-api/src/main/java/com/cakk/api/controller/user/MyPageController.java
+++ b/cakk-api/src/main/java/com/cakk/api/controller/user/MyPageController.java
@@ -14,8 +14,10 @@ import lombok.RequiredArgsConstructor;
 
 import com.cakk.api.annotation.SignInUser;
 import com.cakk.api.dto.request.like.HeartCakeSearchRequest;
+import com.cakk.api.dto.request.like.HeartCakeShopSearchRequest;
 import com.cakk.api.dto.request.user.ProfileUpdateRequest;
 import com.cakk.api.dto.response.like.HeartCakeImageListResponse;
+import com.cakk.api.dto.response.like.HeartCakeShopListResponse;
 import com.cakk.api.dto.response.user.ProfileInformationResponse;
 import com.cakk.api.service.like.HeartService;
 import com.cakk.api.service.user.UserService;
@@ -64,6 +66,16 @@ public class MyPageController {
 		@Valid @ModelAttribute HeartCakeSearchRequest request
 	) {
 		final HeartCakeImageListResponse response = heartService.findCakeImagesByCursorAndHeart(request, user);
+
+		return ApiResponse.success(response);
+	}
+
+	@GetMapping("/heart-shops")
+	public ApiResponse<HeartCakeShopListResponse> heartCakeList(
+		@SignInUser User user,
+		@Valid @ModelAttribute HeartCakeShopSearchRequest request
+	) {
+		final HeartCakeShopListResponse response = heartService.findCakeShopByCursorAndHeart(request, user);
 
 		return ApiResponse.success(response);
 	}

--- a/cakk-api/src/main/java/com/cakk/api/dto/request/like/HeartCakeShopSearchRequest.java
+++ b/cakk-api/src/main/java/com/cakk/api/dto/request/like/HeartCakeShopSearchRequest.java
@@ -1,0 +1,10 @@
+package com.cakk.api.dto.request.like;
+
+import jakarta.validation.constraints.NotNull;
+
+public record HeartCakeShopSearchRequest(
+	Long cakeShopHeartId,
+	@NotNull
+	Integer pageSize
+) {
+}

--- a/cakk-api/src/main/java/com/cakk/api/dto/response/like/HeartCakeShopListResponse.java
+++ b/cakk-api/src/main/java/com/cakk/api/dto/response/like/HeartCakeShopListResponse.java
@@ -1,0 +1,16 @@
+package com.cakk.api.dto.response.like;
+
+import java.util.List;
+
+import lombok.Builder;
+
+import com.cakk.domain.mysql.dto.param.like.HeartCakeShopResponseParam;
+
+@Builder
+public record HeartCakeShopListResponse(
+
+	List<HeartCakeShopResponseParam> cakeShops,
+	Long lastCakeShopHeartId,
+	int size
+) {
+}

--- a/cakk-api/src/main/java/com/cakk/api/mapper/ShopMapper.java
+++ b/cakk-api/src/main/java/com/cakk/api/mapper/ShopMapper.java
@@ -9,12 +9,15 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 import com.cakk.api.dto.request.shop.CreateShopRequest;
+import com.cakk.api.dto.response.like.HeartCakeShopListResponse;
 import com.cakk.api.dto.response.shop.CakeShopByMapResponse;
 import com.cakk.api.dto.response.shop.CakeShopDetailResponse;
 import com.cakk.api.dto.response.shop.CakeShopInfoResponse;
 import com.cakk.api.dto.response.shop.CakeShopSearchResponse;
 import com.cakk.api.dto.response.shop.CakeShopSimpleResponse;
 import com.cakk.common.enums.Days;
+import com.cakk.common.utils.SetUtils;
+import com.cakk.domain.mysql.dto.param.like.HeartCakeShopResponseParam;
 import com.cakk.domain.mysql.dto.param.shop.CakeShopByKeywordParam;
 import com.cakk.domain.mysql.dto.param.shop.CakeShopDetailParam;
 import com.cakk.domain.mysql.dto.param.shop.CakeShopInfoParam;
@@ -122,6 +125,17 @@ public class ShopMapper {
 			.cakeShops(cakeShops)
 			.lastCakeShopId(cakeShops.isEmpty() ? null : cakeShops.get(size - 1).getCakeShopId())
 			.size(cakeShops.size())
+			.build();
+	}
+
+	public static HeartCakeShopListResponse supplyHeartCakeShopListResponseBy(final List<HeartCakeShopResponseParam> cakeShops) {
+		final int size = cakeShops.size();
+		cakeShops.forEach(it -> SetUtils.keepOnlyNElements(it.cakeImageUrls(), 4));
+
+		return HeartCakeShopListResponse.builder()
+			.cakeShops(cakeShops)
+			.lastCakeShopHeartId(cakeShops.isEmpty() ? null : cakeShops.get(size - 1).cakeShopHeartId())
+			.size(size)
 			.build();
 	}
 }

--- a/cakk-api/src/main/java/com/cakk/api/service/like/HeartService.java
+++ b/cakk-api/src/main/java/com/cakk/api/service/like/HeartService.java
@@ -9,10 +9,14 @@ import lombok.RequiredArgsConstructor;
 
 import com.cakk.api.annotation.DistributedLock;
 import com.cakk.api.dto.request.like.HeartCakeSearchRequest;
+import com.cakk.api.dto.request.like.HeartCakeShopSearchRequest;
 import com.cakk.api.dto.response.like.HeartCakeImageListResponse;
+import com.cakk.api.dto.response.like.HeartCakeShopListResponse;
 import com.cakk.api.mapper.CakeMapper;
+import com.cakk.api.mapper.ShopMapper;
 import com.cakk.common.enums.RedisKey;
 import com.cakk.domain.mysql.dto.param.like.HeartCakeImageResponseParam;
+import com.cakk.domain.mysql.dto.param.like.HeartCakeShopResponseParam;
 import com.cakk.domain.mysql.entity.cake.Cake;
 import com.cakk.domain.mysql.entity.cake.CakeHeart;
 import com.cakk.domain.mysql.entity.shop.CakeShop;
@@ -49,6 +53,20 @@ public class HeartService {
 		);
 
 		return CakeMapper.supplyHeartCakeImageListResponseBy(cakeImages);
+	}
+
+	@Transactional(readOnly = true)
+	public HeartCakeShopListResponse findCakeShopByCursorAndHeart(
+		final HeartCakeShopSearchRequest dto,
+		final User signInUser
+	) {
+		final List<HeartCakeShopResponseParam> cakeShops = cakeShopHeartReader.searchAllByCursorAndHeart(
+			dto.cakeShopHeartId(),
+			signInUser.getId(),
+			dto.pageSize()
+		);
+
+		return ShopMapper.supplyHeartCakeShopListResponseBy(cakeShops);
 	}
 
 	@DistributedLock

--- a/cakk-api/src/test/java/com/cakk/api/integration/user/HeartIntegrationTest.java
+++ b/cakk-api/src/test/java/com/cakk/api/integration/user/HeartIntegrationTest.java
@@ -1,6 +1,7 @@
 package com.cakk.api.integration.user;
 
 import static org.junit.Assert.*;
+
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.*;
 
 import org.springframework.http.HttpEntity;
@@ -15,10 +16,13 @@ import org.springframework.web.util.UriComponentsBuilder;
 import com.cakk.api.common.annotation.TestWithDisplayName;
 import com.cakk.api.common.base.IntegrationTest;
 import com.cakk.api.dto.request.like.HeartCakeSearchRequest;
+import com.cakk.api.dto.request.like.HeartCakeShopSearchRequest;
 import com.cakk.api.dto.response.like.HeartCakeImageListResponse;
+import com.cakk.api.dto.response.like.HeartCakeShopListResponse;
 import com.cakk.common.enums.ReturnCode;
 import com.cakk.common.response.ApiResponse;
 import com.cakk.domain.mysql.dto.param.like.HeartCakeImageResponseParam;
+import com.cakk.domain.mysql.dto.param.like.HeartCakeShopResponseParam;
 
 @SqlGroup({
 	@Sql(scripts = {
@@ -98,5 +102,107 @@ public class HeartIntegrationTest extends IntegrationTest {
 			.orElse(null);
 		assertEquals(lastCakeLikeId, data.lastCakeHeartId());
 		assertEquals(0, data.size());
+	}
+
+	@TestWithDisplayName("하트 한 케이크 샵 목록을 조회한다.")
+	void listByHeartShops1() {
+		// given
+		final String url = "%s%d%s/heart-shops".formatted(BASE_URL, port, API_URL);
+		final HeartCakeShopSearchRequest params = new HeartCakeShopSearchRequest(null, 6);
+		final UriComponents uriComponents = UriComponentsBuilder
+			.fromUriString(url)
+			.queryParam("cakeShopHeartId", params.cakeShopHeartId())
+			.queryParam("pageSize", params.pageSize())
+			.build();
+
+		// when
+		final ResponseEntity<ApiResponse> responseEntity = restTemplate.exchange(
+			uriComponents.toUriString(),
+			HttpMethod.GET,
+			new HttpEntity<>(getAuthHeader()),
+			ApiResponse.class);
+
+		// then
+		final ApiResponse response = objectMapper.convertValue(responseEntity.getBody(), ApiResponse.class);
+		final HeartCakeShopListResponse data = objectMapper.convertValue(response.getData(), HeartCakeShopListResponse.class);
+
+		assertEquals(HttpStatusCode.valueOf(200), responseEntity.getStatusCode());
+		assertEquals(ReturnCode.SUCCESS.getCode(), response.getReturnCode());
+		assertEquals(ReturnCode.SUCCESS.getMessage(), response.getReturnMessage());
+
+		final Long lastCakeLikeId = data.cakeShops().stream()
+			.map(HeartCakeShopResponseParam::cakeShopHeartId)
+			.min(Long::compareTo)
+			.orElse(null);
+		assertEquals(lastCakeLikeId, data.lastCakeShopHeartId());
+		assertEquals(params.pageSize().intValue(), data.size());
+	}
+
+	@TestWithDisplayName("하트 한 케이크 샵 목록을 2개만 조회한다.")
+	void listByHeartShops2() {
+		// given
+		final String url = "%s%d%s/heart-shops".formatted(BASE_URL, port, API_URL);
+		final HeartCakeShopSearchRequest params = new HeartCakeShopSearchRequest(null, 2);
+		final UriComponents uriComponents = UriComponentsBuilder
+			.fromUriString(url)
+			.queryParam("cakeShopHeartId", params.cakeShopHeartId())
+			.queryParam("pageSize", params.pageSize())
+			.build();
+
+		// when
+		final ResponseEntity<ApiResponse> responseEntity = restTemplate.exchange(
+			uriComponents.toUriString(),
+			HttpMethod.GET,
+			new HttpEntity<>(getAuthHeader()),
+			ApiResponse.class);
+
+		// then
+		final ApiResponse response = objectMapper.convertValue(responseEntity.getBody(), ApiResponse.class);
+		final HeartCakeShopListResponse data = objectMapper.convertValue(response.getData(), HeartCakeShopListResponse.class);
+
+		assertEquals(HttpStatusCode.valueOf(200), responseEntity.getStatusCode());
+		assertEquals(ReturnCode.SUCCESS.getCode(), response.getReturnCode());
+		assertEquals(ReturnCode.SUCCESS.getMessage(), response.getReturnMessage());
+
+		final Long lastCakeLikeId = data.cakeShops().stream()
+			.map(HeartCakeShopResponseParam::cakeShopHeartId)
+			.min(Long::compareTo)
+			.orElse(null);
+		assertEquals(lastCakeLikeId, data.lastCakeShopHeartId());
+		assertEquals(params.pageSize().intValue(), data.size());
+	}
+
+	@TestWithDisplayName("하트 한 케이크 샵 목록이 없을 경우 빈 배열을 조회한다.")
+	void listByHeartShops3() {
+		// given
+		final String url = "%s%d%s/heart-shops".formatted(BASE_URL, port, API_URL);
+		final HeartCakeShopSearchRequest params = new HeartCakeShopSearchRequest(1L, 2);
+		final UriComponents uriComponents = UriComponentsBuilder
+			.fromUriString(url)
+			.queryParam("cakeShopHeartId", params.cakeShopHeartId())
+			.queryParam("pageSize", params.pageSize())
+			.build();
+
+		// when
+		final ResponseEntity<ApiResponse> responseEntity = restTemplate.exchange(
+			uriComponents.toUriString(),
+			HttpMethod.GET,
+			new HttpEntity<>(getAuthHeader()),
+			ApiResponse.class);
+
+		// then
+		final ApiResponse response = objectMapper.convertValue(responseEntity.getBody(), ApiResponse.class);
+		final HeartCakeShopListResponse data = objectMapper.convertValue(response.getData(), HeartCakeShopListResponse.class);
+
+		assertEquals(HttpStatusCode.valueOf(200), responseEntity.getStatusCode());
+		assertEquals(ReturnCode.SUCCESS.getCode(), response.getReturnCode());
+		assertEquals(ReturnCode.SUCCESS.getMessage(), response.getReturnMessage());
+
+		final Long lastCakeLikeId = data.cakeShops().stream()
+			.map(HeartCakeShopResponseParam::cakeShopHeartId)
+			.min(Long::compareTo)
+			.orElse(null);
+		assertEquals(lastCakeLikeId, data.lastCakeShopHeartId());
+		assertNotEquals(params.pageSize().intValue(), data.size());
 	}
 }

--- a/cakk-api/src/test/resources/sql/insert-cake.sql
+++ b/cakk-api/src/test/resources/sql/insert-cake.sql
@@ -22,6 +22,24 @@ values (1, 'thumbnail_url1', '케이크 맛집1', '케이크 맛집입니다.', 
        (9, 'thumbnail_url9', '케이크 맛집9', '케이크 맛집입니다.', '서울시 강남구 어쩌고로3', '케이크 맛집입니다.', ST_GeomFromText(@g9, 4326), 0, 0, false, now(), now()),
        (10, 'thumbnail_url10', '케이크 맛집10', '케이크 맛집입니다.', '서울시 강남구 어쩌고로3', '케이크 맛집입니다.', ST_GeomFromText(@g10, 4326), 0, 0, false, now(), now());
 
+insert into cake_shop_operation (operation_id, shop_id, operation_day, start_time, end_time, created_at, updated_at)
+values (1, 1, 0, '10:00:00', '22:00:00', now(), now()),
+       (2, 1, 1, '10:00:00', '22:00:00', now(), now()),
+       (3, 1, 2, '10:00:00', '20:00:00', now(), now()),
+       (4, 1, 3, '10:00:00', '22:00:00', now(), now()),
+       (5, 1, 4, '10:00:00', '22:00:00', now(), now()),
+       (6, 2, 0, '8:00:00', '21:00:00', now(), now()),
+       (7, 2, 2, '8:00:00', '21:00:00', now(), now()),
+       (8, 2, 4, '8:00:00', '21:00:00', now(), now()),
+       (9, 3, 5, '7:00:00', '19:00:00', now(), now()),
+       (10, 4, 6, '7:00:00', '19:00:00', now(), now()),
+       (11, 5, 6, '7:00:00', '19:00:00', now(), now()),
+       (12, 6, 6, '7:00:00', '19:00:00', now(), now()),
+       (13, 7, 6, '7:00:00', '19:00:00', now(), now()),
+       (14, 8, 6, '7:00:00', '19:00:00', now(), now()),
+       (15, 9, 6, '7:00:00', '19:00:00', now(), now()),
+       (16, 10, 6, '7:00:00', '19:00:00', now(), now());
+
 insert into cake (cake_id, shop_id, cake_image_url, heart_count, created_at, updated_at)
 values (1, 1, 'cake_image_url1', 0, now(), now()),
        (2, 1, 'cake_image_url2', 0, now(), now()),

--- a/cakk-api/src/test/resources/sql/insert-heart.sql
+++ b/cakk-api/src/test/resources/sql/insert-heart.sql
@@ -7,4 +7,9 @@ values (1, 3, 1, now()),
        (6, 4, 1, now());
 
 insert into cake_shop_heart (shop_heart_id, shop_id, user_id, created_at)
-values (1, 1, 1, now());
+values (1, 4, 1, now()),
+       (2, 3, 1, now()),
+       (3, 9, 1, now()),
+       (4, 5, 1, now()),
+       (5, 7, 1, now()),
+       (6, 1, 1, now());

--- a/cakk-common/src/main/java/com/cakk/common/utils/SetUtils.java
+++ b/cakk-common/src/main/java/com/cakk/common/utils/SetUtils.java
@@ -1,0 +1,28 @@
+package com.cakk.common.utils;
+
+import java.util.Iterator;
+import java.util.Set;
+
+public class SetUtils {
+
+	private SetUtils() {
+		throw new IllegalStateException("util class");
+	}
+
+	public static <T> void keepOnlyNElements(final Set<T> set, final int max) {
+		if (set == null || set.size() <= max) {
+			return;
+		}
+
+		final Iterator<T> iterator = set.iterator();
+		int count = 0;
+
+		while (iterator.hasNext()) {
+			iterator.next();
+			count++;
+			if (count > max) {
+				iterator.remove();
+			}
+		}
+	}
+}

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/dto/param/like/HeartCakeShopResponseParam.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/dto/param/like/HeartCakeShopResponseParam.java
@@ -1,0 +1,16 @@
+package com.cakk.domain.mysql.dto.param.like;
+
+import java.util.Set;
+
+import com.cakk.common.enums.Days;
+
+public record HeartCakeShopResponseParam(
+	Long cakeShopHeartId,
+	Long cakeShopId,
+	String thumbnailUrl,
+	String cakeShopName,
+	String cakeShopBio,
+	Set<String> cakeImageUrls,
+	Set<Days> operationDays
+) {
+}

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/query/CakeShopHeartQueryRepository.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/query/CakeShopHeartQueryRepository.java
@@ -1,0 +1,96 @@
+package com.cakk.domain.mysql.repository.query;
+
+import static com.cakk.domain.mysql.entity.cake.QCake.*;
+import static com.cakk.domain.mysql.entity.shop.QCakeShop.*;
+import static com.cakk.domain.mysql.entity.shop.QCakeShopHeart.*;
+import static com.cakk.domain.mysql.entity.shop.QCakeShopOperation.*;
+import static com.cakk.domain.mysql.entity.user.QUser.*;
+import static com.querydsl.core.group.GroupBy.*;
+import static java.util.Objects.*;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+import com.cakk.domain.mysql.dto.param.like.HeartCakeShopResponseParam;
+
+@RequiredArgsConstructor
+@Repository
+public class CakeShopHeartQueryRepository {
+
+	private final JPAQueryFactory queryFactory;
+
+	public List<Long> searchIdsByCursorAndHeart(
+		final Long cakeShopHeartId,
+		final Long userId,
+		final int pageSize
+	) {
+		return queryFactory
+			.select(cakeShopHeart.id)
+			.from(cakeShopHeart)
+			.where(
+				ltCakeShopHeartId(cakeShopHeartId),
+				isHeart(userId)
+			)
+			.limit(pageSize)
+			.fetch();
+	}
+
+	public List<HeartCakeShopResponseParam> searchAllByCursorAndHeart(final List<Long> cakeShopHeartIds) {
+		return queryFactory
+			.selectFrom(cakeShopHeart)
+			.innerJoin(cakeShop)
+			.on(cakeShopHeart.cakeShop.eq(cakeShop))
+			.innerJoin(user)
+			.on(cakeShopHeart.user.eq(user))
+			.innerJoin(cakeShopOperation)
+			.on(cakeShop.eq(cakeShopOperation.cakeShop))
+			.innerJoin(cake)
+			.on(cakeShop.eq(cake.cakeShop))
+			.where(inCakeShopHeartIds(cakeShopHeartIds))
+			.orderBy(cakeShopHeartIdDesc())
+			.transform(groupBy(cakeShopHeart.id)
+				.list(Projections.constructor(HeartCakeShopResponseParam.class,
+						cakeShopHeart.id,
+						cakeShop.id,
+						cakeShop.thumbnailUrl,
+						cakeShop.shopName,
+						cakeShop.shopBio,
+						set(cake.cakeImageUrl),
+						set(cakeShopOperation.operationDay)
+					)
+				)
+			);
+	}
+
+	private BooleanExpression ltCakeShopHeartId(Long cakeShopHeartId) {
+		if (isNull(cakeShopHeartId)) {
+			return null;
+		}
+
+		return cakeShopHeart.id.lt(cakeShopHeartId);
+	}
+
+	private BooleanExpression inCakeShopHeartIds(List<Long> cakeShopHeartIds) {
+		if (isNull(cakeShopHeartIds) || cakeShopHeartIds.isEmpty()) {
+			return null;
+		}
+
+		return cakeShopHeart.id.in(cakeShopHeartIds);
+	}
+
+	private BooleanExpression isHeart(Long userId) {
+		return cakeShopHeart.user.id.eq(userId);
+	}
+
+	private OrderSpecifier<Long> cakeShopHeartIdDesc() {
+		return cakeShopHeart.id.desc();
+	}
+}

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/reader/CakeHeartReader.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/reader/CakeHeartReader.java
@@ -20,11 +20,11 @@ public class CakeHeartReader {
 	private final CakeHeartQueryRepository cakeHeartQueryRepository;
 
 	public List<HeartCakeImageResponseParam> searchCakeImagesByCursorAndHeart(
-		final Long cakeLikeId,
+		final Long cakeHeartId,
 		final Long userId,
 		final int pageSize
 	) {
-		return cakeHeartQueryRepository.searchCakeImagesByCursorAndHeart(cakeLikeId, userId, pageSize);
+		return cakeHeartQueryRepository.searchCakeImagesByCursorAndHeart(cakeHeartId, userId, pageSize);
 	}
 
 	public CakeHeart findOrNullByUserAndCake(final User user, final Cake cake) {

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/reader/CakeShopHeartReader.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/reader/CakeShopHeartReader.java
@@ -1,18 +1,33 @@
 package com.cakk.domain.mysql.repository.reader;
 
+import java.util.List;
+
 import lombok.RequiredArgsConstructor;
 
 import com.cakk.domain.mysql.annotation.Reader;
+import com.cakk.domain.mysql.dto.param.like.HeartCakeShopResponseParam;
 import com.cakk.domain.mysql.entity.shop.CakeShop;
 import com.cakk.domain.mysql.entity.shop.CakeShopHeart;
 import com.cakk.domain.mysql.entity.user.User;
 import com.cakk.domain.mysql.repository.jpa.CakeShopHeartJpaRepository;
+import com.cakk.domain.mysql.repository.query.CakeShopHeartQueryRepository;
 
 @Reader
 @RequiredArgsConstructor
 public class CakeShopHeartReader {
 
+	private final CakeShopHeartQueryRepository cakeShopHeartQueryRepository;
 	private final CakeShopHeartJpaRepository cakeShopHeartJpaRepository;
+
+	public List<HeartCakeShopResponseParam> searchAllByCursorAndHeart(
+		final Long cakeShopHeartId,
+		final Long userId,
+		final int pageSize
+	) {
+		final List<Long> cakeShopHeartIds = cakeShopHeartQueryRepository.searchIdsByCursorAndHeart(cakeShopHeartId, userId, pageSize);
+
+		return cakeShopHeartQueryRepository.searchAllByCursorAndHeart(cakeShopHeartIds);
+	}
 
 	public CakeShopHeart findOrNullByUserAndCakeShop(final User user, final CakeShop cakeShop) {
 		return cakeShopHeartJpaRepository.findByUserAndCakeShop(user, cakeShop).orElse(null);


### PR DESCRIPTION
> ### Issue Number

#79

> ### Description

저번에 말씀해주신 것처럼 pageSize만큼 가져오지 못하는 경우가 있습니다. 이를 해결하기 위해 아래와 같이 id를 먼저 조회했습니다.

```java
    select
        csh1_0.shop_heart_id 
    from
        cake_shop_heart csh1_0 
    where
        csh1_0.user_id=:userId
    limit :pageSize
```

이후 id 리스트를 활용하여 케이크 샵을 조회했습니다.

```java
select
        csh1_0.shop_heart_id,
        cs1_0.shop_id,
        cs1_0.thumbnail_url,
        cs1_0.shop_name,
        cs1_0.shop_bio,
        c1_0.cake_image_url,
        cso1_0.operation_day 
    from
        cake_shop_heart csh1_0 
    join
        cake_shop cs1_0 
            on csh1_0.shop_id=cs1_0.shop_id 
    join
        users u1_0 
            on csh1_0.user_id=u1_0.user_id 
    join
        cake_shop_operation cso1_0 
            on cs1_0.shop_id=cso1_0.shop_id 
    join
        cake c1_0 
            on cs1_0.shop_id=c1_0.shop_id 
    where
        csh1_0.shop_heart_id in :cakeShopIds 
    order by
        csh1_0.shop_heart_id desc
```

기존에 구현해주신 CakeShops 컬렉션은 멤버변수가 달라 활용하지 못했습니다.

> ### Core Code

```java
// CakeShopHeartReader.java

	public List<HeartCakeShopResponseParam> searchAllByCursorAndHeart(
		final Long cakeShopHeartId,
		final Long userId,
		final int pageSize
	) {
		final List<Long> cakeShopHeartIds = cakeShopHeartQueryRepository.searchIdsByCursorAndHeart(cakeShopHeartId, userId, pageSize);

		return cakeShopHeartQueryRepository.searchAllByCursorAndHeart(cakeShopHeartIds);
	}
```

> ### etc
