### PR TITLE
Feature: 케이크 상세 조회, 생성 기능 추가

### DIFF
--- a/cakk-api/src/main/java/com/cakk/api/controller/cake/CakeController.java
+++ b/cakk-api/src/main/java/com/cakk/api/controller/cake/CakeController.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -14,11 +15,13 @@ import org.springframework.web.bind.annotation.RestController;
 import lombok.RequiredArgsConstructor;
 
 import com.cakk.api.annotation.SignInUser;
+import com.cakk.api.dto.request.cake.CakeCreateRequest;
 import com.cakk.api.dto.request.cake.CakeSearchByCategoryRequest;
 import com.cakk.api.dto.request.cake.CakeSearchByLocationRequest;
 import com.cakk.api.dto.request.cake.CakeSearchByShopRequest;
 import com.cakk.api.dto.request.cake.CakeSearchByViewsRequest;
 import com.cakk.api.dto.request.cake.CakeUpdateRequest;
+import com.cakk.api.dto.response.cake.CakeDetailResponse;
 import com.cakk.api.dto.response.cake.CakeImageListResponse;
 import com.cakk.api.service.cake.CakeService;
 import com.cakk.api.service.like.HeartService;
@@ -67,6 +70,24 @@ public class CakeController {
 		final CakeImageListResponse response = cakeService.searchCakeImagesByCursorAndViews(request);
 
 		return ApiResponse.success(response);
+	}
+
+	@GetMapping("/{cakeId}")
+	public ApiResponse<CakeDetailResponse> getCakeDetail(@PathVariable Long cakeId) {
+		final CakeDetailResponse response = cakeService.findCakeDetailById(cakeId);
+
+		return ApiResponse.success(response);
+	}
+
+	@PostMapping("/{cakeShopId}")
+	public ApiResponse<Void> createCake(
+		@SignInUser User user,
+		@PathVariable Long cakeShopId,
+		@Valid @RequestBody CakeCreateRequest request
+	) {
+		cakeService.createCake(request.toParam(user, cakeShopId));
+
+		return ApiResponse.success();
 	}
 
 	@PutMapping("/{cakeId}/heart")

--- a/cakk-api/src/main/java/com/cakk/api/dto/request/cake/CakeCreateRequest.java
+++ b/cakk-api/src/main/java/com/cakk/api/dto/request/cake/CakeCreateRequest.java
@@ -3,6 +3,7 @@ package com.cakk.api.dto.request.cake;
 import java.util.List;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 import com.cakk.api.mapper.CakeDesignCategoryMapper;
@@ -14,7 +15,9 @@ import com.cakk.domain.mysql.entity.user.User;
 public record CakeCreateRequest(
 	@NotBlank @Size(max = 200)
 	String cakeImageUrl,
+	@NotNull
 	List<CakeDesignCategory> cakeDesignCategories,
+	@NotNull
 	List<String> tagNames
 ) {
 

--- a/cakk-api/src/main/java/com/cakk/api/dto/request/cake/CakeCreateRequest.java
+++ b/cakk-api/src/main/java/com/cakk/api/dto/request/cake/CakeCreateRequest.java
@@ -1,0 +1,29 @@
+package com.cakk.api.dto.request.cake;
+
+import java.util.List;
+
+import jakarta.validation.constraints.NotBlank;
+
+import com.cakk.api.mapper.CakeDesignCategoryMapper;
+import com.cakk.api.mapper.CakeMapper;
+import com.cakk.common.enums.CakeDesignCategory;
+import com.cakk.domain.mysql.dto.param.cake.CakeCreateParam;
+import com.cakk.domain.mysql.entity.user.User;
+
+public record CakeCreateRequest(
+	@NotBlank
+	String cakeImageUrl,
+	List<CakeDesignCategory> cakeDesignCategories,
+	List<String> tagNames
+) {
+
+	public CakeCreateParam toParam(User user, Long cakeShopId) {
+		return new CakeCreateParam(
+			CakeMapper.supplyCakeBy(cakeImageUrl),
+			CakeDesignCategoryMapper.supplyCakeCategoryListBy(cakeDesignCategories),
+			tagNames,
+			user,
+			cakeShopId
+		);
+	}
+}

--- a/cakk-api/src/main/java/com/cakk/api/dto/request/cake/CakeCreateRequest.java
+++ b/cakk-api/src/main/java/com/cakk/api/dto/request/cake/CakeCreateRequest.java
@@ -3,6 +3,7 @@ package com.cakk.api.dto.request.cake;
 import java.util.List;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 import com.cakk.api.mapper.CakeDesignCategoryMapper;
 import com.cakk.api.mapper.CakeMapper;
@@ -11,7 +12,7 @@ import com.cakk.domain.mysql.dto.param.cake.CakeCreateParam;
 import com.cakk.domain.mysql.entity.user.User;
 
 public record CakeCreateRequest(
-	@NotBlank
+	@NotBlank @Size(max = 200)
 	String cakeImageUrl,
 	List<CakeDesignCategory> cakeDesignCategories,
 	List<String> tagNames

--- a/cakk-api/src/main/java/com/cakk/api/dto/request/cake/CakeUpdateRequest.java
+++ b/cakk-api/src/main/java/com/cakk/api/dto/request/cake/CakeUpdateRequest.java
@@ -3,6 +3,7 @@ package com.cakk.api.dto.request.cake;
 import java.util.List;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 import com.cakk.api.mapper.CakeDesignCategoryMapper;
 import com.cakk.common.enums.CakeDesignCategory;
@@ -12,7 +13,9 @@ import com.cakk.domain.mysql.entity.user.User;
 public record CakeUpdateRequest(
 	@NotBlank
 	String cakeImageUrl,
+	@NotNull
 	List<CakeDesignCategory> cakeDesignCategories,
+	@NotNull
 	List<String> tagNames
 ) {
 

--- a/cakk-api/src/main/java/com/cakk/api/dto/request/operation/UpdateShopOperationRequest.java
+++ b/cakk-api/src/main/java/com/cakk/api/dto/request/operation/UpdateShopOperationRequest.java
@@ -2,12 +2,12 @@ package com.cakk.api.dto.request.operation;
 
 import java.util.List;
 
+import jakarta.validation.constraints.NotNull;
+
 import com.cakk.api.mapper.ShopOperationMapper;
 import com.cakk.domain.mysql.dto.param.operation.UpdateShopOperationParam;
 import com.cakk.domain.mysql.entity.shop.CakeShopOperation;
 import com.cakk.domain.mysql.entity.user.User;
-
-import jakarta.validation.constraints.NotNull;
 
 public record UpdateShopOperationRequest(
 	@NotNull

--- a/cakk-api/src/main/java/com/cakk/api/dto/request/operation/UpdateShopOperationRequest.java
+++ b/cakk-api/src/main/java/com/cakk/api/dto/request/operation/UpdateShopOperationRequest.java
@@ -7,7 +7,10 @@ import com.cakk.domain.mysql.dto.param.operation.UpdateShopOperationParam;
 import com.cakk.domain.mysql.entity.shop.CakeShopOperation;
 import com.cakk.domain.mysql.entity.user.User;
 
+import jakarta.validation.constraints.NotNull;
+
 public record UpdateShopOperationRequest(
+	@NotNull
 	List<ShopOperationParam> operationDays
 ) {
 

--- a/cakk-api/src/main/java/com/cakk/api/dto/request/shop/UpdateShopAddressRequest.java
+++ b/cakk-api/src/main/java/com/cakk/api/dto/request/shop/UpdateShopAddressRequest.java
@@ -4,13 +4,14 @@ import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 import com.cakk.api.mapper.PointMapper;
 import com.cakk.domain.mysql.dto.param.shop.UpdateShopAddressParam;
 import com.cakk.domain.mysql.entity.user.User;
 
 public record UpdateShopAddressRequest(
-	@NotBlank
+	@NotBlank @Size(max = 50)
 	String shopAddress,
 	@NotNull @Min(-90) @Max(90)
 	Double latitude,

--- a/cakk-api/src/main/java/com/cakk/api/dto/response/cake/CakeDetailResponse.java
+++ b/cakk-api/src/main/java/com/cakk/api/dto/response/cake/CakeDetailResponse.java
@@ -1,0 +1,20 @@
+package com.cakk.api.dto.response.cake;
+
+import java.util.Set;
+
+import lombok.Builder;
+
+import com.cakk.common.enums.CakeDesignCategory;
+import com.cakk.domain.mysql.dto.param.tag.TagParam;
+
+
+@Builder
+public record CakeDetailResponse(
+	String cakeImageUrl,
+	String cakeShopName,
+	String shopBio,
+	Long cakeShopId,
+	Set<CakeDesignCategory> cakeCategories,
+	Set<TagParam> tags
+) {
+}

--- a/cakk-api/src/main/java/com/cakk/api/mapper/CakeMapper.java
+++ b/cakk-api/src/main/java/com/cakk/api/mapper/CakeMapper.java
@@ -6,10 +6,13 @@ import java.util.List;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
+import com.cakk.api.dto.response.cake.CakeDetailResponse;
 import com.cakk.api.dto.response.cake.CakeImageListResponse;
 import com.cakk.api.dto.response.like.HeartCakeImageListResponse;
+import com.cakk.domain.mysql.dto.param.cake.CakeDetailParam;
 import com.cakk.domain.mysql.dto.param.cake.CakeImageResponseParam;
 import com.cakk.domain.mysql.dto.param.like.HeartCakeImageResponseParam;
+import com.cakk.domain.mysql.entity.cake.Cake;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class CakeMapper {
@@ -51,6 +54,23 @@ public class CakeMapper {
 			.cakeImages(cakeImages)
 			.lastCakeHeartId(cakeImages.isEmpty() ? null : cakeImages.get(size - 1).cakeHeartId())
 			.size(cakeImages.size())
+			.build();
+	}
+
+	public static CakeDetailResponse cakeDetailResponseFromParam(CakeDetailParam param) {
+		return CakeDetailResponse.builder()
+			.cakeShopId(param.cakeShopId())
+			.cakeShopName(param.cakeShopName())
+			.cakeImageUrl(param.cakeImageUrl())
+			.shopBio(param.shopBio())
+			.cakeCategories(param.cakeCategories())
+			.tags(param.tags())
+			.build();
+	}
+
+	public static Cake supplyCakeBy(String cakeImageUrl) {
+		return Cake.builder()
+			.cakeImageUrl(cakeImageUrl)
 			.build();
 	}
 }

--- a/cakk-api/src/test/resources/sql/insert-cake.sql
+++ b/cakk-api/src/test/resources/sql/insert-cake.sql
@@ -11,16 +11,16 @@ SET @g10 = 'Point(37.541530 127.054164)';
 
 insert into cake_shop (shop_id, thumbnail_url, shop_name, shop_address, shop_bio, shop_description, location, like_count, heart_count, linked_flag,
                        created_at, updated_at)
-values (1, 'thumbnail_url1', '케이크 맛집1', '케이크 맛집입니다.', '서울시 강남구 어쩌고로1', '케이크 맛집입니다.', ST_GeomFromText(@g1, 4326), 0, 0, false, now(), now()),
-       (2, 'thumbnail_url2', '케이크 맛집2', '케이크 맛집입니다.', '서울시 강남구 어쩌고로2', '케이크 맛집입니다.', ST_GeomFromText(@g2, 4326), 0, 0, false, now(), now()),
-       (3, 'thumbnail_url3', '케이크 맛집3', '케이크 맛집입니다.', '서울시 강남구 어쩌고로3', '케이크 맛집입니다.', ST_GeomFromText(@g3, 4326), 0, 0, false, now(), now()),
-       (4, 'thumbnail_url4', '케이크 맛집4', '케이크 맛집입니다.', '서울시 강남구 어쩌고로3', '케이크 맛집입니다.', ST_GeomFromText(@g4, 4326), 0, 0, false, now(), now()),
-       (5, 'thumbnail_url5', '케이크 맛집5', '케이크 맛집입니다.', '서울시 강남구 어쩌고로3', '케이크 맛집입니다.', ST_GeomFromText(@g5, 4326), 0, 0, false, now(), now()),
-       (6, 'thumbnail_url6', '케이크 맛집6', '케이크 맛집입니다.', '서울시 강남구 어쩌고로3', '케이크 맛집입니다.', ST_GeomFromText(@g6, 4326), 0, 0, false, now(), now()),
-       (7, 'thumbnail_url7', '케이크 맛집7', '케이크 맛집입니다.', '서울시 강남구 어쩌고로3', '케이크 맛집입니다.', ST_GeomFromText(@g7, 4326), 0, 0, false, now(), now()),
-       (8, 'thumbnail_url8', '케이크 맛집8', '케이크 맛집입니다.', '서울시 강남구 어쩌고로3', '케이크 맛집입니다.', ST_GeomFromText(@g8, 4326), 0, 0, false, now(), now()),
-       (9, 'thumbnail_url9', '케이크 맛집9', '케이크 맛집입니다.', '서울시 강남구 어쩌고로3', '케이크 맛집입니다.', ST_GeomFromText(@g9, 4326), 0, 0, false, now(), now()),
-       (10, 'thumbnail_url10', '케이크 맛집10', '케이크 맛집입니다.', '서울시 강남구 어쩌고로3', '케이크 맛집입니다.', ST_GeomFromText(@g10, 4326), 0, 0, false, now(), now());
+values (1, 'thumbnail_url1', '케이크 맛집1', '서울시 강남구 어쩌고로1', '케이크 맛집입니다.', '케이크 맛집입니다.', ST_GeomFromText(@g1, 4326), 0, 0, false, now(), now()),
+       (2, 'thumbnail_url2', '케이크 맛집2', '서울시 강남구 어쩌고로2', '케이크 맛집입니다.', '케이크 맛집입니다.', ST_GeomFromText(@g2, 4326), 0, 0, false, now(), now()),
+       (3, 'thumbnail_url3', '케이크 맛집3', '서울시 강남구 어쩌고로3', '케이크 맛집입니다.', '케이크 맛집입니다.', ST_GeomFromText(@g3, 4326), 0, 0, false, now(), now()),
+       (4, 'thumbnail_url4', '케이크 맛집4', '서울시 강남구 어쩌고로4', '케이크 맛집입니다.', '케이크 맛집입니다.', ST_GeomFromText(@g4, 4326), 0, 0, false, now(), now()),
+       (5, 'thumbnail_url5', '케이크 맛집5', '서울시 강남구 어쩌고로5', '케이크 맛집입니다.', '케이크 맛집입니다.', ST_GeomFromText(@g5, 4326), 0, 0, false, now(), now()),
+       (6, 'thumbnail_url6', '케이크 맛집6', '서울시 강남구 어쩌고로6', '케이크 맛집입니다.', '케이크 맛집입니다.', ST_GeomFromText(@g6, 4326), 0, 0, false, now(), now()),
+       (7, 'thumbnail_url7', '케이크 맛집7', '서울시 강남구 어쩌고로7', '케이크 맛집입니다.', '케이크 맛집입니다.', ST_GeomFromText(@g7, 4326), 0, 0, false, now(), now()),
+       (8, 'thumbnail_url8', '케이크 맛집8', '서울시 강남구 어쩌고로8', '케이크 맛집입니다.', '케이크 맛집입니다.', ST_GeomFromText(@g8, 4326), 0, 0, false, now(), now()),
+       (9, 'thumbnail_url9', '케이크 맛집9', '서울시 강남구 어쩌고로9', '케이크 맛집입니다.', '케이크 맛집입니다.', ST_GeomFromText(@g9, 4326), 0, 0, false, now(), now()),
+       (10, 'thumbnail_url10', '케이크 맛집10', '서울시 강남구 어쩌고로10', '케이크 맛집입니다.', '케이크 맛집입니다.', ST_GeomFromText(@g10, 4326), 0, 0, false, now(), now());
 
 insert into cake_shop_operation (operation_id, shop_id, operation_day, start_time, end_time, created_at, updated_at)
 values (1, 1, 0, '10:00:00', '22:00:00', now(), now()),

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/dto/param/cake/CakeCreateParam.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/dto/param/cake/CakeCreateParam.java
@@ -1,0 +1,16 @@
+package com.cakk.domain.mysql.dto.param.cake;
+
+import java.util.List;
+
+import com.cakk.domain.mysql.entity.cake.Cake;
+import com.cakk.domain.mysql.entity.cake.CakeCategory;
+import com.cakk.domain.mysql.entity.user.User;
+
+public record CakeCreateParam(
+	Cake cake,
+	List<CakeCategory> cakeCategories,
+	List<String> tagNames,
+	User owner,
+	Long cakeShopId
+) {
+}

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/dto/param/cake/CakeDetailParam.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/dto/param/cake/CakeDetailParam.java
@@ -1,0 +1,16 @@
+package com.cakk.domain.mysql.dto.param.cake;
+
+import java.util.Set;
+
+import com.cakk.common.enums.CakeDesignCategory;
+import com.cakk.domain.mysql.dto.param.tag.TagParam;
+
+public record CakeDetailParam(
+	String cakeImageUrl,
+	String cakeShopName,
+	String shopBio,
+	Long cakeShopId,
+	Set<CakeDesignCategory> cakeCategories,
+	Set<TagParam> tags
+) {
+}

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/dto/param/tag/TagParam.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/dto/param/tag/TagParam.java
@@ -1,0 +1,7 @@
+package com.cakk.domain.mysql.dto.param.tag;
+
+public record TagParam(
+	Long tagId,
+	String tagName
+) {
+}

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/entity/cake/Cake.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/entity/cake/Cake.java
@@ -20,6 +20,7 @@ import jakarta.persistence.Table;
 import org.hibernate.annotations.ColumnDefault;
 
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -58,6 +59,7 @@ public class Cake extends AuditEntity {
 	@Column(name = "deleted_at")
 	private LocalDateTime deletedAt;
 
+	@Builder
 	public Cake(String cakeImageUrl, CakeShop cakeShop) {
 		this.cakeImageUrl = cakeImageUrl;
 		this.cakeShop = cakeShop;
@@ -97,5 +99,20 @@ public class Cake extends AuditEntity {
 
 	public void removeCakeTags() {
 		this.cakeTags.clear();
+	}
+
+	public void registerTags(List<Tag> tags) {
+		tags.forEach(tag -> this.cakeTags.add(CakeTagMapper.supplyCakeTagBy(this, tag)));
+	}
+
+	public void registerCategories(List<CakeCategory> cakeCategories) {
+		cakeCategories.forEach(cakeCategory -> {
+			cakeCategory.updateCake(this);
+			this.cakeCategories.add(cakeCategory);
+		});
+	}
+
+	public void updateCakeShop(CakeShop cakeShop) {
+		this.cakeShop = cakeShop;
 	}
 }

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/entity/shop/CakeShop.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/entity/shop/CakeShop.java
@@ -26,6 +26,7 @@ import lombok.NoArgsConstructor;
 import com.cakk.domain.mysql.dto.param.shop.CakeShopUpdateParam;
 import com.cakk.domain.mysql.dto.param.shop.UpdateShopAddressParam;
 import com.cakk.domain.mysql.entity.audit.AuditEntity;
+import com.cakk.domain.mysql.entity.cake.Cake;
 import com.cakk.domain.mysql.entity.user.BusinessInformation;
 
 @Getter
@@ -82,6 +83,9 @@ public class CakeShop extends AuditEntity {
 
 	@OneToMany(mappedBy = "cakeShop", cascade = CascadeType.PERSIST, orphanRemoval = true)
 	private List<CakeShopOperation> cakeShopOperations = new ArrayList<>();
+
+	@OneToMany(mappedBy = "cakeShop", cascade = CascadeType.PERSIST)
+	private List<Cake> cakes = new ArrayList<>();
 
 	@Builder
 	public CakeShop(
@@ -147,5 +151,10 @@ public class CakeShop extends AuditEntity {
 			cakeShopOperation.updateCakeShop(this);
 			this.cakeShopOperations.add(cakeShopOperation);
 		});
+	}
+
+	public void registerCake(Cake cake) {
+		cake.updateCakeShop(this);
+		this.cakes.add(cake);
 	}
 }

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/query/CakeQueryRepository.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/query/CakeQueryRepository.java
@@ -143,7 +143,7 @@ public class CakeQueryRepository {
 			.fetchOne());
 	}
 
-	public Optional<CakeDetailParam> searchCakeDetailById(Long cakeId) {
+	public CakeDetailParam searchCakeDetailById(Long cakeId) {
 		List<CakeDetailParam> results = queryFactory
 			.selectFrom(cake)
 			.innerJoin(cake.cakeShop, cakeShop)
@@ -163,7 +163,7 @@ public class CakeQueryRepository {
 						tag.tagName)
 					)
 				)));
-		return results.isEmpty() ? Optional.empty() : Optional.ofNullable(results.get(0));
+		return results.isEmpty() ? null : results.get(0);
 	}
 
 	private BooleanExpression ltCakeId(Long cakeId) {

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/query/CakeQueryRepository.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/query/CakeQueryRepository.java
@@ -16,8 +16,6 @@ import java.util.Optional;
 import org.locationtech.jts.geom.Point;
 import org.springframework.stereotype.Repository;
 
-import com.cakk.domain.mysql.dto.param.cake.CakeDetailParam;
-import com.cakk.domain.mysql.dto.param.tag.TagParam;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
@@ -28,7 +26,9 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 
 import com.cakk.common.enums.CakeDesignCategory;
+import com.cakk.domain.mysql.dto.param.cake.CakeDetailParam;
 import com.cakk.domain.mysql.dto.param.cake.CakeImageResponseParam;
+import com.cakk.domain.mysql.dto.param.tag.TagParam;
 import com.cakk.domain.mysql.entity.cake.Cake;
 import com.cakk.domain.mysql.entity.user.User;
 

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/reader/CakeReader.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/reader/CakeReader.java
@@ -1,6 +1,9 @@
 package com.cakk.domain.mysql.repository.reader;
 
+import static java.util.Objects.*;
+
 import java.util.List;
+import java.util.Objects;
 
 import lombok.RequiredArgsConstructor;
 
@@ -58,7 +61,11 @@ public class CakeReader {
 	}
 
 	public CakeDetailParam searchCakeDetailById(Long cakeId) {
-		return cakeQueryRepository.searchCakeDetailById(cakeId)
-			.orElseThrow(() -> new CakkException(ReturnCode.NOT_EXIST_CAKE));
+		CakeDetailParam param = cakeQueryRepository.searchCakeDetailById(cakeId);
+
+		if (isNull(param)) {
+			throw new CakkException(ReturnCode.NOT_EXIST_CAKE);
+		}
+		return param;
 	}
 }

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/reader/CakeReader.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/reader/CakeReader.java
@@ -8,6 +8,7 @@ import com.cakk.common.enums.CakeDesignCategory;
 import com.cakk.common.enums.ReturnCode;
 import com.cakk.common.exception.CakkException;
 import com.cakk.domain.mysql.annotation.Reader;
+import com.cakk.domain.mysql.dto.param.cake.CakeDetailParam;
 import com.cakk.domain.mysql.dto.param.cake.CakeImageResponseParam;
 import com.cakk.domain.mysql.dto.param.cake.CakeSearchParam;
 import com.cakk.domain.mysql.entity.cake.Cake;
@@ -54,5 +55,10 @@ public class CakeReader {
 	public Cake findWithCakeTagsAndCakeCategories(Long cakeId, User owner) {
 		return cakeQueryRepository.searchWithCakeTagsAndCakeCategories(cakeId, owner)
 			.orElseThrow(() -> new CakkException(ReturnCode.NOT_CAKE_SHOP_OWNER));
+	}
+
+	public CakeDetailParam searchCakeDetailById(Long cakeId) {
+		return cakeQueryRepository.searchCakeDetailById(cakeId)
+			.orElseThrow(() -> new CakkException(ReturnCode.NOT_EXIST_CAKE));
 	}
 }


### PR DESCRIPTION
> ### Issue Number

#88 

> ### Description

- 상세 조회 API는 다른 API를 사용하고 있지만 필요성에 의해 만들었습니다.

> ### Core Code
도메인 모델 패턴을 활요한 객체 간의 책임 부여
```java
public CakeDetailResponse findCakeDetailById(Long cakeId) {
	final CakeDetailParam cake = cakeReader.searchCakeDetailById(cakeId);

	return CakeMapper.cakeDetailResponseFromParam(cake);
}

@Transactional
public void createCake(CakeCreateParam param) {
	CakeShop cakeShop = cakeShopReader.findByIdAndOwner(param.cakeShopId(), param.owner());
	Cake cake = param.cake();
	List<Tag> tags = param.tagNames()
		.stream()
		.map(tagName -> tagReader.findByTagName(tagName).orElseGet(() -> tagWriter.saveTag(tagName)))
		.toList();

	cake.registerTags(tags);
	cake.registerCategories(param.cakeCategories());
	cakeShop.registerCake(cake);
}
```

> ### etc
