### PR TITLE
Feature: 케이크 조회수 증가 이벤트 리스닝 구현

### DIFF
--- a/cakk-api/src/main/java/com/cakk/api/controller/shop/ShopController.java
+++ b/cakk-api/src/main/java/com/cakk/api/controller/shop/ShopController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
@@ -32,6 +33,7 @@ import com.cakk.api.dto.response.shop.CakeShopSimpleResponse;
 import com.cakk.api.service.like.HeartService;
 import com.cakk.api.service.like.LikeService;
 import com.cakk.api.service.shop.ShopService;
+import com.cakk.api.service.views.ViewsService;
 import com.cakk.common.response.ApiResponse;
 import com.cakk.domain.mysql.entity.user.User;
 
@@ -43,6 +45,7 @@ public class ShopController {
 	private final ShopService shopService;
 	private final HeartService heartService;
 	private final LikeService likeService;
+	private final ViewsService viewsService;
 
 	@PostMapping("/certification")
 	public ApiResponse<Void> requestCertification(
@@ -70,9 +73,12 @@ public class ShopController {
 
 	@GetMapping("/{cakeShopId}/simple")
 	public ApiResponse<CakeShopSimpleResponse> simple(
-		@PathVariable Long cakeShopId
+		@PathVariable Long cakeShopId,
+		@RequestParam(required = false) Long cakeId
 	) {
 		final CakeShopSimpleResponse response = shopService.searchSimpleById(cakeShopId);
+		viewsService.increaseCakeViews(cakeId);
+
 		return ApiResponse.success(response);
 	}
 

--- a/cakk-api/src/main/java/com/cakk/api/listener/shop/CertificationEventListener.java
+++ b/cakk-api/src/main/java/com/cakk/api/listener/shop/CertificationEventListener.java
@@ -1,4 +1,4 @@
-package com.cakk.api.event.shop.listener;
+package com.cakk.api.event.shop;
 
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;

--- a/cakk-api/src/main/java/com/cakk/api/listener/shop/CertificationEventListener.java
+++ b/cakk-api/src/main/java/com/cakk/api/listener/shop/CertificationEventListener.java
@@ -1,4 +1,4 @@
-package com.cakk.api.event.shop;
+package com.cakk.api.listener.shop;
 
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;

--- a/cakk-api/src/main/java/com/cakk/api/listener/views/ViewsIncreaseEventListener.java
+++ b/cakk-api/src/main/java/com/cakk/api/listener/views/ViewsIncreaseEventListener.java
@@ -1,0 +1,24 @@
+package com.cakk.api.listener.views;
+
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import lombok.RequiredArgsConstructor;
+
+import com.cakk.domain.mysql.event.views.CakeIncreaseViewsEvent;
+import com.cakk.domain.redis.repository.CakeViewRedisRepository;
+
+@RequiredArgsConstructor
+@Component
+public class ViewsIncreaseEventListener {
+
+	private final CakeViewRedisRepository cakeViewRedisRepository;
+
+	@Async
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void increaseViews(final CakeIncreaseViewsEvent event) {
+		cakeViewRedisRepository.saveOrIncreaseSearchCount(event.cakeId());
+	}
+}

--- a/cakk-api/src/main/java/com/cakk/api/service/views/ViewsService.java
+++ b/cakk-api/src/main/java/com/cakk/api/service/views/ViewsService.java
@@ -1,0 +1,39 @@
+package com.cakk.api.service.views;
+
+import static java.util.Objects.*;
+
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+import com.cakk.common.exception.CakkException;
+import com.cakk.domain.mysql.entity.cake.Cake;
+import com.cakk.domain.mysql.event.views.CakeIncreaseViewsEvent;
+import com.cakk.domain.mysql.repository.reader.CakeReader;
+
+@RequiredArgsConstructor
+@Service
+public class ViewsService {
+
+	private final CakeReader cakeReader;
+
+	private final ApplicationEventPublisher publisher;
+
+	@Transactional(readOnly = true)
+	public void increaseCakeViews(final Long cakeId) {
+		if (isNull(cakeId)) {
+			return;
+		}
+
+		try {
+			final Cake cake = cakeReader.findById(cakeId);
+			final CakeIncreaseViewsEvent event = cake.getInCreaseViewsEvent();
+
+			publisher.publishEvent(event);
+		} catch (CakkException ignored) {
+			// ignored
+		}
+	}
+}

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/entity/cake/Cake.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/entity/cake/Cake.java
@@ -26,6 +26,8 @@ import lombok.NoArgsConstructor;
 
 import com.cakk.domain.mysql.entity.audit.AuditEntity;
 import com.cakk.domain.mysql.entity.shop.CakeShop;
+import com.cakk.domain.mysql.event.EventMapper;
+import com.cakk.domain.mysql.event.views.CakeIncreaseViewsEvent;
 import com.cakk.domain.mysql.mapper.CakeTagMapper;
 
 @Getter
@@ -114,5 +116,9 @@ public class Cake extends AuditEntity {
 
 	public void updateCakeShop(CakeShop cakeShop) {
 		this.cakeShop = cakeShop;
+	}
+
+	public CakeIncreaseViewsEvent getInCreaseViewsEvent() {
+		return EventMapper.supplyCakeIncreaseViewsEvent(this.id);
 	}
 }

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/event/EventMapper.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/event/EventMapper.java
@@ -6,6 +6,7 @@ import lombok.NoArgsConstructor;
 import com.cakk.domain.mysql.dto.param.user.CertificationParam;
 import com.cakk.domain.mysql.entity.shop.CakeShop;
 import com.cakk.domain.mysql.event.shop.CertificationEvent;
+import com.cakk.domain.mysql.event.views.CakeIncreaseViewsEvent;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class EventMapper {
@@ -31,5 +32,9 @@ public class EventMapper {
 			.userId(param.user().getId())
 			.userEmail(param.user().getEmail())
 			.build();
+	}
+
+	public static CakeIncreaseViewsEvent supplyCakeIncreaseViewsEvent(Long cakeId) {
+		return new CakeIncreaseViewsEvent(cakeId);
 	}
 }

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/event/views/CakeIncreaseViewsEvent.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/event/views/CakeIncreaseViewsEvent.java
@@ -1,0 +1,6 @@
+package com.cakk.domain.mysql.event.views;
+
+public record CakeIncreaseViewsEvent(
+	Long cakeId
+) {
+}


### PR DESCRIPTION
> ### Issue Number

#103

> ### Description

케이크 조회수 증가 이벤트 리스닝 로직을 구현하였습니다. 케이크 리스트에서 케이크를 클릭 시 케이크 샵 간단 조회 API를 호출 하는데, 이 때 Querystring으로 cakeId를 담아서 요청한다면 해당 케이크에 대하여 조회수를 증가시킵니다.

만약 잘못된 cakeId여도 오류가 나지 않도록 처리했습니다.

> ### Core Code

```java
	@Transactional(readOnly = true)
	public void increaseCakeViews(final Long cakeId) {
		if (isNull(cakeId)) {
			return;
		}

		try {
			final Cake cake = cakeReader.findById(cakeId);
			final CakeIncreaseViewsEvent event = cake.getInCreaseViewsEvent();

			publisher.publishEvent(event);
		} catch (CakkException ignored) {
			// ignored
		}
	}
```

> ### etc
