### PR TITLE
Fix: 검색 시 위치 기반 미동의 시 조건부 로직으로 수정

### DIFF
--- a/cakk-api/src/main/java/com/cakk/api/dto/request/cake/CakeSearchByLocationRequest.java
+++ b/cakk-api/src/main/java/com/cakk/api/dto/request/cake/CakeSearchByLocationRequest.java
@@ -2,7 +2,6 @@ package com.cakk.api.dto.request.cake;
 
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotNull;
 
 import com.cakk.api.mapper.PointMapper;
 import com.cakk.domain.mysql.dto.param.cake.CakeSearchParam;
@@ -10,9 +9,9 @@ import com.cakk.domain.mysql.dto.param.cake.CakeSearchParam;
 public record CakeSearchByLocationRequest(
 	Long cakeId,
 	String keyword,
-	@NotNull @Min(-90) @Max(90)
+	@Min(-90) @Max(90)
 	Double latitude,
-	@NotNull @Min(-180) @Max(180)
+	@Min(-180) @Max(180)
 	Double longitude,
 	Integer pageSize
 ) {

--- a/cakk-api/src/main/java/com/cakk/api/dto/request/shop/CakeShopSearchRequest.java
+++ b/cakk-api/src/main/java/com/cakk/api/dto/request/shop/CakeShopSearchRequest.java
@@ -2,7 +2,6 @@ package com.cakk.api.dto.request.shop;
 
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotNull;
 
 import com.cakk.api.mapper.PointMapper;
 import com.cakk.domain.mysql.dto.param.shop.CakeShopSearchParam;
@@ -10,9 +9,9 @@ import com.cakk.domain.mysql.dto.param.shop.CakeShopSearchParam;
 public record CakeShopSearchRequest(
 	Long cakeShopId,
 	String keyword,
-	@NotNull @Min(-90) @Max(90)
+	@Min(-90) @Max(90)
 	Double latitude,
-	@NotNull @Min(-180) @Max(180)
+	@Min(-180) @Max(180)
 	Double longitude,
 	Integer pageSize
 ) {

--- a/cakk-api/src/test/java/com/cakk/api/integration/cake/CakeIntegrationTest.java
+++ b/cakk-api/src/test/java/com/cakk/api/integration/cake/CakeIntegrationTest.java
@@ -250,7 +250,7 @@ class CakeIntegrationTest extends IntegrationTest {
 	}
 
 	@TestWithDisplayName("검색어, 태그명, 케이크 카테고리, 사용자 위치를 포함한 동적 검색, SQL 파일 기준 10개가 조회된다")
-	void searchCakeImagesByTextAndLocation1() {
+	void searchCakeImagesByKeywordAndLocation1() {
 		final String url = "%s%d%s/search/cakes".formatted(BASE_URL, port, API_URL);
 		final UriComponents uriComponents = UriComponentsBuilder
 			.fromUriString(url)
@@ -275,7 +275,7 @@ class CakeIntegrationTest extends IntegrationTest {
 	}
 
 	@TestWithDisplayName("검색어, 태그명, 케이크 카테고리, 사용자 위치를 포함한 동적 검색, SQL 파일 기준 7개가 조회된다")
-	void searchCakeImagesByTextAndLocation2() {
+	void searchCakeImagesByKeywordAndLocation2() {
 		final String url = "%s%d%s/search/cakes".formatted(BASE_URL, port, API_URL);
 		final UriComponents uriComponents = UriComponentsBuilder
 			.fromUriString(url)
@@ -300,7 +300,7 @@ class CakeIntegrationTest extends IntegrationTest {
 	}
 
 	@TestWithDisplayName("사용자 위치를 포함한 동적 검색, SQL 파일 기준 10개가 조회된다")
-	void searchCakeImagesByTextAndLocation3() {
+	void searchCakeImagesByKeywordAndLocation3() {
 		final String url = "%s%d%s/search/cakes".formatted(BASE_URL, port, API_URL);
 		final UriComponents uriComponents = UriComponentsBuilder
 			.fromUriString(url)
@@ -321,6 +321,30 @@ class CakeIntegrationTest extends IntegrationTest {
 		assertEquals(ReturnCode.SUCCESS.getMessage(), response.getReturnMessage());
 
 		assertEquals(10, data.cakeImages().size());
+	}
+
+	@TestWithDisplayName("검색어와 커서 아이디로 동적 검색, SQL 파일 기준 4개가 조회된다")
+	void searchCakeImagesByKeyword() {
+		final String url = "%s%d%s/search/cakes".formatted(BASE_URL, port, API_URL);
+		final UriComponents uriComponents = UriComponentsBuilder
+			.fromUriString(url)
+			.queryParam("cakeId", 5)
+			.queryParam("keyword", "tag")
+			.queryParam("pageSize", 10)
+			.build();
+
+		// when
+		final ResponseEntity<ApiResponse> responseEntity = restTemplate.getForEntity(uriComponents.toUriString(), ApiResponse.class);
+
+		// then
+		final ApiResponse response = objectMapper.convertValue(responseEntity.getBody(), ApiResponse.class);
+		final CakeImageListResponse data = objectMapper.convertValue(response.getData(), CakeImageListResponse.class);
+
+		assertEquals(HttpStatusCode.valueOf(200), responseEntity.getStatusCode());
+		assertEquals(ReturnCode.SUCCESS.getCode(), response.getReturnCode());
+		assertEquals(ReturnCode.SUCCESS.getMessage(), response.getReturnMessage());
+
+		assertEquals(4, data.cakeImages().size());
 	}
 
 	@TestWithDisplayName("조회수로 케이크 이미지 조회에 성공한다")

--- a/cakk-api/src/test/java/com/cakk/api/integration/shop/ShopIntegrationTest.java
+++ b/cakk-api/src/test/java/com/cakk/api/integration/shop/ShopIntegrationTest.java
@@ -559,6 +559,36 @@ class ShopIntegrationTest extends IntegrationTest {
 		});
 	}
 
+	@TestWithDisplayName("테스트 sql script를 기준 4개의 케이크샵이 조회된다")
+	void searchCakeShopsByKeywordWithConditions3() {
+		final String url = "%s%d%s/search/shops".formatted(BASE_URL, port, API_URL);
+		final UriComponents uriComponents = UriComponentsBuilder
+			.fromUriString(url)
+			.queryParam("cakeShopId", 5)
+			.queryParam("keyword", "케이크")
+			.queryParam("pageSize", 10)
+			.build();
+
+		//when
+		final ResponseEntity<ApiResponse> responseEntity = restTemplate.getForEntity(uriComponents.toUriString(), ApiResponse.class);
+
+		//then
+		final ApiResponse response = objectMapper.convertValue(responseEntity.getBody(), ApiResponse.class);
+		final CakeShopSearchResponse data = objectMapper.convertValue(response.getData(), CakeShopSearchResponse.class);
+
+		assertEquals(HttpStatusCode.valueOf(200), responseEntity.getStatusCode());
+		assertEquals(ReturnCode.SUCCESS.getCode(), response.getReturnCode());
+		assertEquals(ReturnCode.SUCCESS.getMessage(), response.getReturnMessage());
+
+		assertEquals(4, data.size());
+		data.cakeShops().forEach(cakeShop -> {
+			assertThat(cakeShop.cakeImageUrls().size()).isLessThanOrEqualTo(4);
+			assertThat(cakeShop.cakeShopId()).isNotNull();
+			assertThat(cakeShop.cakeShopName()).isNotNull();
+			assertThat(cakeShop.operationDays()).isNotNull();
+		});
+	}
+
 	@TestWithDisplayName("케이크 샵 기본 정보 업데이트에 성공한다")
 	void updateCakeShopDefaultInfo() {
 		// given

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/query/CakeQueryRepository.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/query/CakeQueryRepository.java
@@ -94,7 +94,7 @@ public class CakeQueryRepository {
 			.leftJoin(cakeCategory)
 			.on(cakeCategory.cake.eq(cake))
 			.where(
-				includeDistance(location).and(containKeyword(keyword)), ltCakeId(cakeId)
+				containKeyword(keyword).and(includeDistance(location)), ltCakeId(cakeId)
 			)
 			.orderBy(cakeIdDesc())
 			.limit(pageSize)

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/query/CakeShopQueryRepository.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/query/CakeShopQueryRepository.java
@@ -118,7 +118,7 @@ public class CakeShopQueryRepository {
 	public Optional<CakeShop> findWithBusinessInformationAndOwnerById(User owner, Long cakeShopId) {
 		return Optional.ofNullable(queryFactory
 			.selectFrom(cakeShop)
-			.join(cakeShop.businessInformation, businessInformation)
+			.innerJoin(cakeShop.businessInformation, businessInformation).fetchJoin()
 			.join(businessInformation.user, user)
 			.where(cakeShop.id.eq(cakeShopId), businessInformation.user.eq(owner))
 			.fetchOne());

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/query/CakeShopQueryRepository.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/query/CakeShopQueryRepository.java
@@ -108,7 +108,7 @@ public class CakeShopQueryRepository {
 			.leftJoin(cakeShop.cakes).fetchJoin()
 			.leftJoin(cakeShop.cakeShopOperations).fetchJoin()
 			.where(
-				includeDistance(location).and(containKeyword(keyword)), ltCakeShopId(cakeShopId)
+				containKeyword(keyword).and(includeDistance(location)), ltCakeShopId(cakeShopId)
 			)
 			.orderBy(cakeShopIdDesc())
 			.limit(pageSize)


### PR DESCRIPTION
> ### Issue Number

#102 

> ### Description

- OneToOne은 Lazy Loading이 안되기에 fetch join으로 수정
- 검색 API에서 위치 정보 Optional로 변경 및 쿼리 순서 변경

> ### Core Code

```java

```

> ### etc
