### PR TITLE
Feature: 인기 케이크 샵 조회 구현

### DIFF
--- a/cakk-api/src/main/java/com/cakk/api/controller/shop/ShopController.java
+++ b/cakk-api/src/main/java/com/cakk/api/controller/shop/ShopController.java
@@ -18,6 +18,7 @@ import lombok.RequiredArgsConstructor;
 import com.cakk.api.annotation.SignInUser;
 import com.cakk.api.dto.request.link.UpdateLinkRequest;
 import com.cakk.api.dto.request.operation.UpdateShopOperationRequest;
+import com.cakk.api.dto.request.shop.CakeShopSearchByViewsRequest;
 import com.cakk.api.dto.request.shop.CakeShopSearchRequest;
 import com.cakk.api.dto.request.shop.CreateShopRequest;
 import com.cakk.api.dto.request.shop.PromotionRequest;
@@ -206,6 +207,15 @@ public class ShopController {
 		@PathVariable Long cakeShopId
 	) {
 		final CakeShopOwnerResponse response = shopService.isExistBusinessInformation(user, cakeShopId);
+
+		return ApiResponse.success(response);
+	}
+
+	@GetMapping("/search/views")
+	public ApiResponse<CakeShopSearchResponse> listByViews(
+		@Valid @ModelAttribute CakeShopSearchByViewsRequest request
+	) {
+		final CakeShopSearchResponse response = shopService.searchCakeShopsByCursorAndViews(request);
 
 		return ApiResponse.success(response);
 	}

--- a/cakk-api/src/main/java/com/cakk/api/dto/request/shop/CakeShopSearchByViewsRequest.java
+++ b/cakk-api/src/main/java/com/cakk/api/dto/request/shop/CakeShopSearchByViewsRequest.java
@@ -1,0 +1,10 @@
+package com.cakk.api.dto.request.shop;
+
+import jakarta.validation.constraints.NotNull;
+
+public record CakeShopSearchByViewsRequest(
+	Long offset,
+	@NotNull
+	Integer pageSize
+) {
+}

--- a/cakk-api/src/main/java/com/cakk/api/mapper/ShopMapper.java
+++ b/cakk-api/src/main/java/com/cakk/api/mapper/ShopMapper.java
@@ -70,11 +70,11 @@ public class ShopMapper {
 
 		operationDays.forEach(operationParam -> cakeShopOperations
 			.add(CakeShopOperation.builder()
-			.operationDay(operationParam.operationDay())
-			.operationStartTime(operationParam.operationStartTime())
-			.operationEndTime(operationParam.operationEndTime())
-			.cakeShop(cakeShop)
-			.build()));
+				.operationDay(operationParam.operationDay())
+				.operationStartTime(operationParam.operationStartTime())
+				.operationEndTime(operationParam.operationEndTime())
+				.cakeShop(cakeShop)
+				.build()));
 
 		return cakeShopOperations;
 	}
@@ -203,12 +203,7 @@ public class ShopMapper {
 		}
 		return new CakeShopByMineResponse(
 			true,
-			result
-				.stream()
-				.findAny()
-				.get()
-				.getCakeShop()
-				.getId()
+			result.stream().findAny().get().getCakeShop().getId()
 		);
 	}
 }

--- a/cakk-api/src/test/java/com/cakk/api/integration/cake/CakeIntegrationTest.java
+++ b/cakk-api/src/test/java/com/cakk/api/integration/cake/CakeIntegrationTest.java
@@ -365,9 +365,7 @@ class CakeIntegrationTest extends IntegrationTest {
 		// then
 		final ApiResponse response = objectMapper.convertValue(responseEntity.getBody(), ApiResponse.class);
 		final CakeImageListResponse data = objectMapper.convertValue(response.getData(), CakeImageListResponse.class);
-		data.cakeImages().forEach(cakeImage -> {
-			System.out.println(cakeImage.cakeId());
-		});
+
 		assertEquals(HttpStatusCode.valueOf(200), responseEntity.getStatusCode());
 		assertEquals(ReturnCode.SUCCESS.getCode(), response.getReturnCode());
 		assertEquals(ReturnCode.SUCCESS.getMessage(), response.getReturnMessage());

--- a/cakk-api/src/test/resources/application-test.yml
+++ b/cakk-api/src/test/resources/application-test.yml
@@ -42,6 +42,11 @@ storage:
       data-source-properties:
         rewriteBatchedStatements: true
 
+decorator:
+  datasource:
+    p6spy:
+      enable-logging: false
+
 slack:
   webhook:
     is-enable: false

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/bo/CakeShops.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/bo/CakeShops.java
@@ -9,13 +9,13 @@ public class CakeShops<T extends CakeShopParam> {
 
 	private List<T> cakeShops;
 
-	public CakeShops(List<T> cakeShops) {
-		validationImageCountMaxFour(cakeShops);
+	public CakeShops(List<T> cakeShops, int imageMaxCount) {
+		validationImageCountMaxCount(cakeShops, imageMaxCount);
 		this.cakeShops = cakeShops;
 	}
 
-	public CakeShops(List<T> cakeShops, int pageSize) {
-		validationImageCountMaxFour(cakeShops);
+	public CakeShops(List<T> cakeShops, int imageMaxCount, int pageSize) {
+		validationImageCountMaxCount(cakeShops, imageMaxCount);
 		cakeShops = validationPageSize(cakeShops, pageSize);
 		this.cakeShops = cakeShops;
 	}
@@ -24,10 +24,10 @@ public class CakeShops<T extends CakeShopParam> {
 		return cakeShops;
 	}
 
-	private void validationImageCountMaxFour(List<T> cakeShops) {
+	private void validationImageCountMaxCount(List<T> cakeShops, final int maxCount) {
 		cakeShops.forEach(cakeShop -> {
-			if (cakeShop.getCakeImageUrls().size() > 4) {
-				cakeShop.setImageCountMaxFour();
+			if (cakeShop.getCakeImageUrls().size() > maxCount) {
+				cakeShop.setImageCountMaxCount(maxCount);
 			}
 		});
 	}

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/dto/param/shop/CakeShopParam.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/dto/param/shop/CakeShopParam.java
@@ -22,8 +22,8 @@ public class CakeShopParam {
 	private Set<String> cakeImageUrls;
 
 
-	public void setImageCountMaxFour() {
-		cakeImageUrls = cakeImageUrls.stream().limit(4).collect(Collectors.toSet());
+	public void setImageCountMaxCount(final int maxCount) {
+		cakeImageUrls = cakeImageUrls.stream().limit(maxCount).collect(Collectors.toSet());
 	}
 }
 

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/query/CakeShopQueryRepository.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/query/CakeShopQueryRepository.java
@@ -191,8 +191,22 @@ public class CakeShopQueryRepository {
 					cakeShop.location)));
 	}
 
+	public List<CakeShop> searchByShopIds(List<Long> shopIds) {
+		return queryFactory
+			.selectFrom(cakeShop)
+			.innerJoin(cakeShop.businessInformation).fetchJoin()
+			.leftJoin(cakeShop.cakes).fetchJoin()
+			.leftJoin(cakeShop.cakeShopOperations).fetchJoin()
+			.where(includeShopIds(shopIds))
+			.fetch();
+	}
+
 	private BooleanExpression eqCakeShopId(Long cakeShopId) {
 		return cakeShop.id.eq(cakeShopId);
+	}
+
+	private BooleanExpression includeShopIds(List<Long> shopIds) {
+		return cakeShop.id.in(shopIds);
 	}
 
 	private BooleanExpression ltCakeShopId(Long cakeShopId) {

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/reader/CakeShopReader.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/reader/CakeShopReader.java
@@ -108,4 +108,8 @@ public class CakeShopReader {
 		return cakeShopQueryRepository.findWithOperations(owner, cakeShopId)
 			.orElseThrow(() -> new CakkException(ReturnCode.NOT_CAKE_SHOP_OWNER));
 	}
+
+	public List<CakeShop> searchShopsByShopIds(List<Long> shopIds) {
+		return cakeShopQueryRepository.searchByShopIds(shopIds);
+	}
 }


### PR DESCRIPTION
> ### Issue Number

#133

> ### Description

인기 케이크 샵 조회를 구현했습니다. 이전에 만드신 일급 컬렉션을 활용하였고, test 속도를 향상시키기 위해 h6spy 를 비활성화 하였습니다.

> ### Core Code

```java
	@Transactional(readOnly = true)
	public CakeShopSearchResponse searchCakeShopsByCursorAndViews(CakeShopSearchByViewsRequest dto) {
		final long offset = isNull(dto.offset()) ? 0 : dto.offset();
		final int pageSize = dto.pageSize();
		final List<Long> cakeShopIds = cakeShopViewsRedisRepository.findTopShopIdsByOffsetAndCount(offset, pageSize);

		if (isNull(cakeShopIds) || cakeShopIds.isEmpty()) {
			return ShopMapper.supplyCakeShopSearchResponseBy(List.of());
		}

		final List<CakeShop> result = cakeShopReader.searchShopsByShopIds(cakeShopIds);
		final List<CakeShopBySearchParam> cakeShopBySearchParams = ShopMapper.supplyCakeShopBySearchParamListBy(result);
		final CakeShops<CakeShopBySearchParam> cakeShops = new CakeShops<>(cakeShopBySearchParams, 6, pageSize);

		return ShopMapper.supplyCakeShopSearchResponseBy(cakeShops.getCakeShops());
	}
```

> ### etc
