### PR TITLE
Chore: jacoco 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,6 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.2.4'
 	id 'io.spring.dependency-management' version '1.1.4'
-	id 'checkstyle'
 }
 
 allprojects {
@@ -20,6 +19,7 @@ subprojects {
 	apply plugin: 'org.springframework.boot'
 	apply plugin: 'io.spring.dependency-management'
 	apply plugin: 'checkstyle'
+	apply plugin: 'jacoco'
 
 	configurations {
 		compileOnly {
@@ -52,6 +52,60 @@ subprojects {
 
 	tasks.named('test') {
 		useJUnitPlatform()
+		finalizedBy 'jacocoTestReport'
+	}
+
+	jacoco {
+		toolVersion = "0.8.12"
+	}
+
+	jacocoTestReport {
+		reports {
+			html.required.set(true)
+			csv.required.set(false)
+			xml.required.set(true)
+		}
+
+		finalizedBy 'jacocoTestCoverageVerification'
+	}
+
+	jacocoTestCoverageVerification {
+		def Qdomains = []
+		for (qPattern in '*.QA'..'*.QZ') { // qPattern = '*.QA', '*.QB', ... '*.QZ'
+			Qdomains.add(qPattern + '*')
+		}
+
+		violationRules {
+			rule {
+				enabled = true
+				element = 'CLASS'
+
+				limit {
+					counter = 'LINE'
+					value = 'COVEREDRATIO'
+					minimum = 0.70
+				}
+
+				limit {
+					counter = 'BRANCH'
+					value = 'COVEREDRATIO'
+					minimum = 0.70
+				}
+
+				limit {
+					counter = "LINE"
+					value = "TOTALCOUNT"
+					maximum = "200".toBigDecimal()
+				}
+
+				excludes = [
+				    "com.cakk.api.dto.**",
+					"com.cakk.api.mapper.**",
+					"com.cakk.api.vo.**",
+					"com.cakk.domain.**"
+				] + Qdomains as List<String>
+			}
+		}
 	}
 }
 

--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,1 @@
+lombok.addLombokGeneratedAnnotation = true


### PR DESCRIPTION
> ### Issue Number

#155

> ### Description

일단 기본적인 jacoco 설정하여 커버리지를 체크할 수 있는 환경을 구성하였습니다. 현재 목표로 잡고 있는 70에 도달하면 80으로 올리거나 codecov 설정에 대해 고려하겠습니다. 다만, 70이라고 해서 70에 딱 맞추기 보다는 같이 최대한 많은 TC를 생산해내는게 목표입니다.

> ### Coverage 미달성 로그

```log
> Rule violated for class com.cakk.api.Application: lines covered ratio is 0.50, but expected minimum is 0.70
  Rule violated for class com.cakk.api.listener.user.EmailSendEventListener: lines covered ratio is 0.00, but expected minimum is 0.70
  Rule violated for class com.cakk.api.provider.oauth.impl.KakaoAuthProvider: lines covered ratio is 0.00, but expected minimum is 0.70
  Rule violated for class com.cakk.api.provider.oauth.impl.GoogleAuthProvider: lines covered ratio is 0.00, but expected minimum is 0.70
  Rule violated for class com.cakk.api.provider.oauth.impl.GoogleAuthProvider: branches covered ratio is 0.00, but expected minimum is 0.70
  Rule violated for class com.cakk.api.provider.oauth.impl.AppleAuthProvider: lines covered ratio is 0.00, but expected minimum is 0.70
  Rule violated for class com.cakk.api.aspect.AopForTransaction: lines covered ratio is 0.50, but expected minimum is 0.70
  Rule violated for class com.cakk.api.controller.advice.GlobalControllerAdvice: lines covered ratio is 0.23, but expected minimum is 0.70
  Rule violated for class com.cakk.api.controller.advice.GlobalControllerAdvice: branches covered ratio is 0.50, but expected minimum is 0.70
  Rule violated for class com.cakk.api.factory.OidcProviderFactory: lines covered ratio is 0.68, but expected minimum is 0.70
  Rule violated for class com.cakk.api.factory.OidcProviderFactory: branches covered ratio is 0.00, but expected minimum is 0.70
  Rule violated for class com.cakk.api.controller.user.SignController: lines covered ratio is 0.40, but expected minimum is 0.70
  Rule violated for class com.cakk.api.filter.JwtExceptionFilter: lines covered ratio is 0.28, but expected minimum is 0.70
  Rule violated for class com.cakk.api.filter.JwtAuthenticationFilter: branches covered ratio is 0.50, but expected minimum is 0.70
  Rule violated for class com.cakk.api.service.user.EmailVerificationService: lines covered ratio is 0.00, but expected minimum is 0.70
  Rule violated for class com.cakk.api.service.user.EmailVerificationService: branches covered ratio is 0.00, but expected minimum is 0.70
  Rule violated for class com.cakk.api.provider.oauth.OidcProvider: lines covered ratio is 0.00, but expected minimum is 0.70
  Rule violated for class com.cakk.api.provider.oauth.PublicKeyProvider: lines covered ratio is 0.11, but expected minimum is 0.70
  Rule violated for class com.cakk.api.service.slack.SlackService: lines covered ratio is 0.11, but expected minimum is 0.70
  Rule violated for class com.cakk.api.service.slack.SlackService: branches covered ratio is 0.12, but expected minimum is 0.70
  Rule violated for class com.cakk.api.resolver.AccessTokenResolver: branches covered ratio is 0.66, but expected minimum is 0.70
  Rule violated for class com.cakk.api.resolver.RefreshTokenResolver: branches covered ratio is 0.50, but expected minimum is 0.70
  Rule violated for class com.cakk.api.resolver.AuthorizedUserResolver: branches covered ratio is 0.66, but expected minimum is 0.70
  Rule violated for class com.cakk.api.controller.s3.AwsS3Controller: lines covered ratio is 0.00, but expected minimum is 0.70
```

> ### etc
