### PR TITLE
Fix: 케이크 샵 검색 시, 페이지네이션이 이루어지지 않은 부분 수정 및 JPA 최적화

### DIFF
--- a/cakk-api/src/main/resources/application.yml
+++ b/cakk-api/src/main/resources/application.yml
@@ -17,6 +17,7 @@ spring:
         dialect: org.hibernate.dialect.MySQLDialect
         format_sql: true
         show_sql: false
+        default_batch_fetch_size: 1000
   jackson:
     date-format: yyyy-MM-dd HH:mm:ss
 

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/query/CakeShopQueryRepository.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/query/CakeShopQueryRepository.java
@@ -105,7 +105,9 @@ public class CakeShopQueryRepository {
 			.selectFrom(cakeShop)
 			.leftJoin(cakeShop.businessInformation).fetchJoin()
 			.where(
-				ltCakeShopId(cakeShopId), containKeyword(keyword).and(includeDistance(location))
+				ltCakeShopId(cakeShopId),
+				includeDistance(location),
+				containKeyword(keyword)
 			)
 			.orderBy(cakeShopIdDesc())
 			.limit(pageSize)

--- a/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/query/CakeShopQueryRepository.java
+++ b/cakk-domain/mysql/src/main/java/com/cakk/domain/mysql/repository/query/CakeShopQueryRepository.java
@@ -103,11 +103,9 @@ public class CakeShopQueryRepository {
 	) {
 		return queryFactory
 			.selectFrom(cakeShop)
-			.innerJoin(cakeShop.businessInformation).fetchJoin()
-			.leftJoin(cakeShop.cakes).fetchJoin()
-			.leftJoin(cakeShop.cakeShopOperations).fetchJoin()
+			.leftJoin(cakeShop.businessInformation).fetchJoin()
 			.where(
-				containKeyword(keyword).and(includeDistance(location)), ltCakeShopId(cakeShopId)
+				ltCakeShopId(cakeShopId), containKeyword(keyword).and(includeDistance(location))
 			)
 			.orderBy(cakeShopIdDesc())
 			.limit(pageSize)


### PR DESCRIPTION
> ### Description

- 필요하지 않은 join 제거
- in 쿼리를 발생시키기 위한 batch size 설정 추가

> ### Core Code

```sql
// 3개의 쿼리로 최적화 - 페이지네이션을 위한 limit 발생
select
        cs1_0.shop_id,
        bi1_0.shop_id,
        bi1_0.business_number,
        bi1_0.created_at,
        bi1_0.updated_at,
        bi1_0.user_id,
        cs1_0.created_at,
        cs1_0.deleted_at,
        cs1_0.heart_count,
        cs1_0.like_count,
        cs1_0.linked_flag,
        cs1_0.location,
        cs1_0.shop_address,
        cs1_0.shop_bio,
        cs1_0.shop_description,
        cs1_0.shop_name,
        cs1_0.thumbnail_url,
        cs1_0.updated_at 
    from
        cake_shop cs1_0 
    left join
        business_information bi1_0 
            on cs1_0.shop_id=bi1_0.shop_id 
    where
        lower(cs1_0.shop_bio) like '%3%' escape '!' 
        or lower(cs1_0.shop_description) like '%3%' escape '!' 
    order by
        cs1_0.shop_id desc 
    limit
        10



select
        c1_0.shop_id,
        c1_0.cake_id,
        c1_0.cake_image_url,
        c1_0.created_at,
        c1_0.deleted_at,
        c1_0.heart_count,
        c1_0.updated_at 
    from
        cake c1_0 
    where
        c1_0.shop_id in (10, 9, 8, 7, 6, 5, 4, 3)

select
    cso1_0.shop_id,
    cso1_0.operation_id,
    cso1_0.created_at,
    cso1_0.operation_day,
    cso1_0.end_time,
    cso1_0.start_time,
    cso1_0.updated_at 
from
    cake_shop_operation cso1_0 
where
    cso1_0.shop_id in (10, 9, 8, 7, 6, 5, 4, 3)
```

> ### etc
