### PR TITLE
Refactor | CAKK-61 | DIP 위반 문제 해결

### DIFF
--- a/cakk-api/build.gradle.kts
+++ b/cakk-api/build.gradle.kts
@@ -37,6 +37,12 @@ dependencies {
 
 	// Point
 	implementation("org.locationtech.jts:jts-core:1.18.2")
+
+	// Mail
+	implementation("org.springframework.boot:spring-boot-starter-mail")
+
+	// Slack
+	implementation("net.gpedro.integrations.slack:slack-webhook:1.4.0")
 }
 
 tasks.bootJar {

--- a/cakk-api/src/main/java/com/cakk/api/config/MessageTemplateConfig.java
+++ b/cakk-api/src/main/java/com/cakk/api/config/MessageTemplateConfig.java
@@ -1,15 +1,43 @@
 package com.cakk.api.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+
+import net.gpedro.integrations.slack.SlackApi;
 
 import com.cakk.external.extractor.CertificationSlackMessageExtractor;
 import com.cakk.external.extractor.ErrorAlertSlackMessageExtractor;
 import com.cakk.external.extractor.MessageExtractor;
+import com.cakk.external.extractor.VerificationCodeMimeMessageExtractor;
+import com.cakk.external.sender.EmailMessageSender;
+import com.cakk.external.sender.MessageSender;
+import com.cakk.external.sender.SlackMessageSender;
 import com.cakk.external.template.MessageTemplate;
 
 @Configuration
 public class MessageTemplateConfig {
+
+	private final JavaMailSender javaMailSender;
+	private final SlackApi slackApi;
+
+	private final String senderEmail;
+	private final Boolean isEnable;
+
+	public MessageTemplateConfig(
+		JavaMailSender javaMailSender,
+		SlackApi slackApi,
+		@Value("${spring.mail.username}")
+		String senderEmail,
+		@Value("${slack.webhook.is-enable}")
+		Boolean isEnable
+	) {
+		this.javaMailSender = javaMailSender;
+		this.senderEmail = senderEmail;
+		this.isEnable = isEnable;
+		this.slackApi = slackApi;
+	}
 
 	@Bean
 	public MessageTemplate certificationTemplate() {
@@ -24,5 +52,20 @@ public class MessageTemplateConfig {
 	@Bean
 	public MessageExtractor errorAlertMessageExtractor() {
 		return new ErrorAlertSlackMessageExtractor();
+	}
+
+	@Bean
+	public MessageExtractor verificationCodeMimeMessageExtractor() {
+		return new VerificationCodeMimeMessageExtractor(javaMailSender, senderEmail);
+	}
+
+	@Bean
+	public MessageSender emailMessageSender() {
+		return new EmailMessageSender(javaMailSender);
+	}
+
+	@Bean
+	public MessageSender slackMessageSender() {
+		return new SlackMessageSender(slackApi, isEnable);
 	}
 }

--- a/cakk-external/src/main/java/com/cakk/external/extractor/VerificationCodeMimeMessageExtractor.kt
+++ b/cakk-external/src/main/java/com/cakk/external/extractor/VerificationCodeMimeMessageExtractor.kt
@@ -6,13 +6,11 @@ import jakarta.mail.internet.MimeMessage
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.mail.javamail.JavaMailSender
 import org.springframework.mail.javamail.MimeMessageHelper
-import org.springframework.stereotype.Component
 
 import com.cakk.common.enums.ReturnCode
 import com.cakk.common.exception.CakkException
 import com.cakk.external.vo.VerificationMessage
 
-@Component
 class VerificationCodeMimeMessageExtractor(
 	private val mailSender: JavaMailSender,
 	@Value("\${spring.mail.username}")

--- a/cakk-external/src/main/java/com/cakk/external/sender/EmailMessageSender.kt
+++ b/cakk-external/src/main/java/com/cakk/external/sender/EmailMessageSender.kt
@@ -3,12 +3,10 @@ package com.cakk.external.sender
 import jakarta.mail.internet.MimeMessage
 
 import org.springframework.mail.javamail.JavaMailSender
-import org.springframework.stereotype.Component
 
 import com.cakk.common.enums.ReturnCode
 import com.cakk.common.exception.CakkException
 
-@Component
 class EmailMessageSender(
 	private val mailSender: JavaMailSender
 ) : MessageSender<MimeMessage> {

--- a/cakk-external/src/main/java/com/cakk/external/sender/SlackMessageSender.kt
+++ b/cakk-external/src/main/java/com/cakk/external/sender/SlackMessageSender.kt
@@ -4,9 +4,7 @@ import net.gpedro.integrations.slack.SlackApi
 import net.gpedro.integrations.slack.SlackMessage
 
 import org.springframework.beans.factory.annotation.Value
-import org.springframework.stereotype.Component
 
-@Component
 class SlackMessageSender(
 	private val slackApi: SlackApi,
 	@Value("\${slack.webhook.is-enable}")


### PR DESCRIPTION
> ### Issue Number

CAKK-61

> ### Description

지난 PR에서 추상화 및 템플릿 콜백 패턴을 적용했으나 API 모듈에서 일부 Extractor와 Sender에 대해서 하위 모듈인 external 모듈에 의존하는, DIP 위반 사례가 있었습니다. 여러 방법을 고민한 끝에 API 모듈에 의존성을 추가 시키고, Extractor와 Sender 의존성 주입에 대한 책임을 API 모듈에 두면서 DIP 문제를 해결했습니다.

> ### Core Code

```java
@Configuration
public class MessageTemplateConfig {

	private final JavaMailSender javaMailSender;
	private final SlackApi slackApi;

	private final String senderEmail;
	private final Boolean isEnable;

	public MessageTemplateConfig(
		JavaMailSender javaMailSender,
		SlackApi slackApi,
		@Value("${spring.mail.username}")
		String senderEmail,
		@Value("${slack.webhook.is-enable}")
		Boolean isEnable
	) {
		this.javaMailSender = javaMailSender;
		this.senderEmail = senderEmail;
		this.isEnable = isEnable;
		this.slackApi = slackApi;
	}

	@Bean
	public MessageTemplate certificationTemplate() {
		return new MessageTemplate();
	}

	@Bean
	public MessageExtractor certificationMessageExtractor() {
		return new CertificationSlackMessageExtractor();
	}

	@Bean
	public MessageExtractor errorAlertMessageExtractor() {
		return new ErrorAlertSlackMessageExtractor();
	}

	@Bean
	public MessageExtractor verificationCodeMimeMessageExtractor() {
		return new VerificationCodeMimeMessageExtractor(javaMailSender, senderEmail);
	}

	@Bean
	public MessageSender emailMessageSender() {
		return new EmailMessageSender(javaMailSender);
	}

	@Bean
	public MessageSender slackMessageSender() {
		return new SlackMessageSender(slackApi, isEnable);
	}
}

```

> ### etc
